### PR TITLE
Enable all the change events

### DIFF
--- a/pkg/api/changeabandoned.go
+++ b/pkg/api/changeabandoned.go
@@ -113,6 +113,10 @@ func newChangeAbandonedEvent() CDEvent {
 			Type:    ChangeAbandonedEventV1,
 			Version: CDEventsSpecVersion,
 		},
-		Subject: ChangeAbandonedSubject{},
+		Subject: ChangeAbandonedSubject{
+			SubjectBase: SubjectBase{
+				Type: ChangeSubjectType,
+			},
+		},
 	}
 }

--- a/pkg/api/changecreated.go
+++ b/pkg/api/changecreated.go
@@ -113,6 +113,10 @@ func newChangeCreatedEvent() CDEvent {
 			Type:    ChangeCreatedEventV1,
 			Version: CDEventsSpecVersion,
 		},
-		Subject: ChangeCreatedSubject{},
+		Subject: ChangeCreatedSubject{
+			SubjectBase: SubjectBase{
+				Type: ChangeSubjectType,
+			},
+		},
 	}
 }

--- a/pkg/api/changemerged.go
+++ b/pkg/api/changemerged.go
@@ -113,6 +113,10 @@ func newChangeMergedEvent() CDEvent {
 			Type:    ChangeMergedEventV1,
 			Version: CDEventsSpecVersion,
 		},
-		Subject: ChangeMergedSubject{},
+		Subject: ChangeMergedSubject{
+			SubjectBase: SubjectBase{
+				Type: ChangeSubjectType,
+			},
+		},
 	}
 }

--- a/pkg/api/changereviewed.go
+++ b/pkg/api/changereviewed.go
@@ -113,6 +113,10 @@ func newChangeReviewedEvent() CDEvent {
 			Type:    ChangeReviewedEventV1,
 			Version: CDEventsSpecVersion,
 		},
-		Subject: ChangeReviewedSubject{},
+		Subject: ChangeReviewedSubject{
+			SubjectBase: SubjectBase{
+				Type: ChangeSubjectType,
+			},
+		},
 	}
 }

--- a/pkg/api/changeupdated.go
+++ b/pkg/api/changeupdated.go
@@ -113,6 +113,10 @@ func newChangeUpdatedEvent() CDEvent {
 			Type:    ChangeUpdatedEventV1,
 			Version: CDEventsSpecVersion,
 		},
-		Subject: ChangeUpdatedSubject{},
+		Subject: ChangeUpdatedSubject{
+			SubjectBase: SubjectBase{
+				Type: ChangeSubjectType,
+			},
+		},
 	}
 }

--- a/pkg/api/factory.go
+++ b/pkg/api/factory.go
@@ -70,21 +70,21 @@ func NewCDEvent(eventType CDEventType) (CDEvent, error) {
 	// case BranchDeletedEventV1:
 	// 	e := newBranchDeletedEvent()
 	// 	return initCDEvent(e)
-	// case ChangeCreatedEventV1:
-	// 	e := newChangeCreatedEvent()
-	// 	return initCDEvent(e)
-	// case ChangeUpdatedEventV1:
-	// 	e := newChangeUpdatedEvent()
-	// 	return initCDEvent(e)
-	// case ChangeReviewedEventV1:
-	// 	e := newChangeReviewedEvent()
-	// 	return initCDEvent(e)
-	// case ChangeMergedEventV1:
-	// 	e := newChangeMergedEvent()
-	// 	return initCDEvent(e)
-	// case ChangeAbandonedEventV1:
-	// 	e := newChangeAbandonedEvent()
-	// 	return initCDEvent(e)
+	case ChangeCreatedEventV1:
+		e := newChangeCreatedEvent()
+		return initCDEvent(e)
+	case ChangeUpdatedEventV1:
+		e := newChangeUpdatedEvent()
+		return initCDEvent(e)
+	case ChangeReviewedEventV1:
+		e := newChangeReviewedEvent()
+		return initCDEvent(e)
+	case ChangeMergedEventV1:
+		e := newChangeMergedEvent()
+		return initCDEvent(e)
+	case ChangeAbandonedEventV1:
+		e := newChangeAbandonedEvent()
+		return initCDEvent(e)
 	// case BuildQueuedEventV1:
 	// 	e := newBuildQueuedEvent()
 	// 	return initCDEvent(e)

--- a/pkg/api/factory_test.go
+++ b/pkg/api/factory_test.go
@@ -53,7 +53,6 @@ func TestNewCDEvent(t *testing.T) {
 		name          string
 		eventType     CDEventType
 		expectedEvent CDEvent
-		shouldFail    bool
 	}{{
 		name:      "pipelinerun queued",
 		eventType: PipelineRunQueuedEventV1,
@@ -70,7 +69,6 @@ func TestNewCDEvent(t *testing.T) {
 				},
 			},
 		},
-		shouldFail: false,
 	}, {
 		name:      "pipelinerun started",
 		eventType: PipelineRunStartedEventV1,
@@ -87,7 +85,6 @@ func TestNewCDEvent(t *testing.T) {
 				},
 			},
 		},
-		shouldFail: false,
 	}, {
 		name:      "pipelinerun finished",
 		eventType: PipelineRunFinishedEventV1,
@@ -104,7 +101,6 @@ func TestNewCDEvent(t *testing.T) {
 				},
 			},
 		},
-		shouldFail: false,
 	}, {
 		name:      "taskrun started",
 		eventType: TaskRunStartedEventV1,
@@ -121,7 +117,6 @@ func TestNewCDEvent(t *testing.T) {
 				},
 			},
 		},
-		shouldFail: false,
 	}, {
 		name:      "taskrun finished",
 		eventType: TaskRunFinishedEventV1,
@@ -138,25 +133,104 @@ func TestNewCDEvent(t *testing.T) {
 				},
 			},
 		},
-		shouldFail: false,
 	}, {
-		name:          "not supported",
-		eventType:     "not supported",
-		expectedEvent: nil,
-		shouldFail:    true,
+		name:      "change created",
+		eventType: ChangeCreatedEventV1,
+		expectedEvent: &ChangeCreatedEvent{
+			Context: Context{
+				Type:      ChangeCreatedEventV1,
+				Timestamp: timeNow(),
+				Id:        testUUID(),
+				Version:   CDEventsSpecVersion,
+			},
+			Subject: ChangeCreatedSubject{
+				SubjectBase: SubjectBase{
+					Type: ChangeSubjectType,
+				},
+			},
+		},
+	}, {
+		name:      "change updated",
+		eventType: ChangeUpdatedEventV1,
+		expectedEvent: &ChangeUpdatedEvent{
+			Context: Context{
+				Type:      ChangeUpdatedEventV1,
+				Timestamp: timeNow(),
+				Id:        testUUID(),
+				Version:   CDEventsSpecVersion,
+			},
+			Subject: ChangeUpdatedSubject{
+				SubjectBase: SubjectBase{
+					Type: ChangeSubjectType,
+				},
+			},
+		},
+	}, {
+		name:      "change reviewed",
+		eventType: ChangeReviewedEventV1,
+		expectedEvent: &ChangeReviewedEvent{
+			Context: Context{
+				Type:      ChangeReviewedEventV1,
+				Timestamp: timeNow(),
+				Id:        testUUID(),
+				Version:   CDEventsSpecVersion,
+			},
+			Subject: ChangeReviewedSubject{
+				SubjectBase: SubjectBase{
+					Type: ChangeSubjectType,
+				},
+			},
+		},
+	}, {
+		name:      "change merged",
+		eventType: ChangeMergedEventV1,
+		expectedEvent: &ChangeMergedEvent{
+			Context: Context{
+				Type:      ChangeMergedEventV1,
+				Timestamp: timeNow(),
+				Id:        testUUID(),
+				Version:   CDEventsSpecVersion,
+			},
+			Subject: ChangeMergedSubject{
+				SubjectBase: SubjectBase{
+					Type: ChangeSubjectType,
+				},
+			},
+		},
+	}, {
+		name:      "change abandoned",
+		eventType: ChangeAbandonedEventV1,
+		expectedEvent: &ChangeAbandonedEvent{
+			Context: Context{
+				Type:      ChangeAbandonedEventV1,
+				Timestamp: timeNow(),
+				Id:        testUUID(),
+				Version:   CDEventsSpecVersion,
+			},
+			Subject: ChangeAbandonedSubject{
+				SubjectBase: SubjectBase{
+					Type: ChangeSubjectType,
+				},
+			},
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			event, err := NewCDEvent(tc.eventType)
-			if err != nil && !tc.shouldFail {
+			if err != nil {
 				t.Fatalf("didn't expected it to fail, but it did: %v", err)
-			}
-			if err == nil && tc.shouldFail {
-				t.Fatalf("expected it to fail, but it didn't")
 			}
 			if d := cmp.Diff(tc.expectedEvent, event); d != "" {
 				t.Errorf("args: diff(-want,+got):\n%s", d)
 			}
 		})
+	}
+}
+
+func TestNewCDEventFailed(t *testing.T) {
+
+	_, err := NewCDEvent("not supported")
+	if err == nil {
+		t.Fatalf("expected it to fail, but it didn't")
 	}
 }


### PR DESCRIPTION
Add tests and enable all the change events.
Those events have no subject details in the spec for now, and the
SDK reflects that. As we spec those events in more details, we
will align the SDK accordingly.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>