### PR TITLE
Directly create specific event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To create a CDEvent, for instance a [*pipelineRun queued*](https://cdevents.dev/
 func main() {
 
     // Create the base event
-    event, err := cdevent.NewCDEvent(cdevent.PipelineRunStartedEventV1)
+    event, err := cdevents.NewPipelineRunQueuedEvent()
     if err != nil {
       log.Fatalf("could not create a cdevent, %v", err)
     }

--- a/pkg/api/artifactpackaged.go
+++ b/pkg/api/artifactpackaged.go
@@ -112,12 +112,17 @@ func (e ArtifactPackagedEvent) GetSchema() string {
 	return artifactPackagedSchemaFile
 }
 
-func newArtifactPackagedEvent() CDEvent {
-	return &ArtifactPackagedEvent{
+func NewArtifactPackagedEvent() (*ArtifactPackagedEvent, error) {
+	e := &ArtifactPackagedEvent{
 		Context: Context{
 			Type:    ArtifactPackagedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: ArtifactPackagedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/artifactpublished.go
+++ b/pkg/api/artifactpublished.go
@@ -112,12 +112,17 @@ func (e ArtifactPublishedEvent) GetSchema() string {
 	return artifactPublishedSchemaFile
 }
 
-func newArtifactPublishedEvent() CDEvent {
-	return &ArtifactPublishedEvent{
+func NewArtifactPublishedEvent() (*ArtifactPublishedEvent, error) {
+	e := &ArtifactPublishedEvent{
 		Context: Context{
 			Type:    ArtifactPublishedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: ArtifactPublishedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/bindings_test.go
+++ b/pkg/api/bindings_test.go
@@ -265,59 +265,57 @@ func init() {
 	}
 }
 
-func makeCDEvent(eventType CDEventType) CDEvent {
-	event, _ := NewCDEvent(eventType)
+func setContext(event CDEventWriter) {
 	event.SetSource(testSource)
 	event.SetSubjectId(testSubjectId)
-	return event
 }
 
 func init() {
-	e := makeCDEvent(PipelineRunQueuedEventV1)
-	pipelineRunQueuedEvent, _ = e.(*PipelineRunQueuedEvent)
+	pipelineRunQueuedEvent, _ = NewPipelineRunQueuedEvent()
+	setContext(pipelineRunQueuedEvent)
 	pipelineRunQueuedEvent.SetSubjectPipelineName(testPipeline)
 	pipelineRunQueuedEvent.SetSubjectURL(testSubjectURL)
 
-	e = makeCDEvent(PipelineRunStartedEventV1)
-	pipelineRunStartedEvent, _ = e.(*PipelineRunStartedEvent)
+	pipelineRunStartedEvent, _ = NewPipelineRunStartedEvent()
+	setContext(pipelineRunStartedEvent)
 	pipelineRunStartedEvent.SetSubjectPipelineName(testPipeline)
 	pipelineRunStartedEvent.SetSubjectURL(testSubjectURL)
 
-	e = makeCDEvent(PipelineRunFinishedEventV1)
-	pipelineRunFinishedEvent, _ = e.(*PipelineRunFinishedEvent)
+	pipelineRunFinishedEvent, _ = NewPipelineRunFinishedEvent()
+	setContext(pipelineRunFinishedEvent)
 	pipelineRunFinishedEvent.SetSubjectPipelineName(testPipeline)
 	pipelineRunFinishedEvent.SetSubjectURL(testSubjectURL)
 	pipelineRunFinishedEvent.SetSubjectOutcome(testPipelineOutcome)
 	pipelineRunFinishedEvent.SetSubjectErrors(testPipelineErrors)
 
-	e = makeCDEvent(TaskRunStartedEventV1)
-	taskRunStartedEvent, _ = e.(*TaskRunStartedEvent)
+	taskRunStartedEvent, _ = NewTaskRunStartedEvent()
+	setContext(taskRunStartedEvent)
 	taskRunStartedEvent.SetSubjectTaskName(testTaskName)
 	taskRunStartedEvent.SetSubjectURL(testSubjectURL)
 	taskRunStartedEvent.SetSubjectPipelineRun(Reference{Id: testSubjectId})
 
-	e = makeCDEvent(TaskRunFinishedEventV1)
-	taskRunFinishedEvent, _ = e.(*TaskRunFinishedEvent)
+	taskRunFinishedEvent, _ = NewTaskRunFinishedEvent()
+	setContext(taskRunFinishedEvent)
 	taskRunFinishedEvent.SetSubjectTaskName(testTaskName)
 	taskRunFinishedEvent.SetSubjectURL(testSubjectURL)
 	taskRunFinishedEvent.SetSubjectPipelineRun(Reference{Id: testSubjectId})
 	taskRunFinishedEvent.SetSubjectOutcome(testTaskOutcome)
 	taskRunFinishedEvent.SetSubjectErrors(testTaskRunErrors)
 
-	e = makeCDEvent(ChangeCreatedEventV1)
-	changeCreatedEvent, _ = e.(*ChangeCreatedEvent)
+	changeCreatedEvent, _ = NewChangeCreatedEvent()
+	setContext(changeCreatedEvent)
 
-	e = makeCDEvent(ChangeUpdatedEventV1)
-	changeUpdatedEvent, _ = e.(*ChangeUpdatedEvent)
+	changeUpdatedEvent, _ = NewChangeUpdatedEvent()
+	setContext(changeUpdatedEvent)
 
-	e = makeCDEvent(ChangeReviewedEventV1)
-	changeReviewedEvent, _ = e.(*ChangeReviewedEvent)
+	changeReviewedEvent, _ = NewChangeReviewedEvent()
+	setContext(changeReviewedEvent)
 
-	e = makeCDEvent(ChangeMergedEventV1)
-	changeMergedEvent, _ = e.(*ChangeMergedEvent)
+	changeMergedEvent, _ = NewChangeMergedEvent()
+	setContext(changeMergedEvent)
 
-	e = makeCDEvent(ChangeAbandonedEventV1)
-	changeAbandonedEvent, _ = e.(*ChangeAbandonedEvent)
+	changeAbandonedEvent, _ = NewChangeAbandonedEvent()
+	setContext(changeAbandonedEvent)
 
 	newUUID, _ := uuidNewRandom()
 	newTime := timeNow().Format(time.RFC3339Nano)

--- a/pkg/api/branchcreated.go
+++ b/pkg/api/branchcreated.go
@@ -112,12 +112,17 @@ func (e BranchCreatedEvent) GetSchema() string {
 	return branchCreatedSchemaFile
 }
 
-func newBranchCreatedEvent() CDEvent {
-	return &BranchCreatedEvent{
+func NewBranchCreatedEvent() (*BranchCreatedEvent, error) {
+	e := &BranchCreatedEvent{
 		Context: Context{
 			Type:    BranchCreatedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: BranchCreatedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/branchdeleted.go
+++ b/pkg/api/branchdeleted.go
@@ -112,12 +112,17 @@ func (e BranchDeletedEvent) GetSchema() string {
 	return branchDeletedSchemaFile
 }
 
-func newBranchDeletedEvent() CDEvent {
-	return &BranchDeletedEvent{
+func NewBranchDeletedEvent() (*BranchDeletedEvent, error) {
+	e := &BranchDeletedEvent{
 		Context: Context{
 			Type:    BranchDeletedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: BranchDeletedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/buildfinished.go
+++ b/pkg/api/buildfinished.go
@@ -112,12 +112,17 @@ func (e BuildFinishedEvent) GetSchema() string {
 	return buildFinishedSchemaFile
 }
 
-func newBuildFinishedEvent() CDEvent {
-	return &BuildFinishedEvent{
+func NewBuildFinishedEvent() (*BuildFinishedEvent, error) {
+	e := &BuildFinishedEvent{
 		Context: Context{
 			Type:    BuildFinishedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: BuildFinishedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/buildqueued.go
+++ b/pkg/api/buildqueued.go
@@ -112,12 +112,17 @@ func (e BuildQueuedEvent) GetSchema() string {
 	return buildQueuedSchemaFile
 }
 
-func newBuildQueuedEvent() CDEvent {
-	return &BuildQueuedEvent{
+func NewBuildQueuedEvent() (*BuildQueuedEvent, error) {
+	e := &BuildQueuedEvent{
 		Context: Context{
 			Type:    BuildQueuedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: BuildQueuedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/buildstarted.go
+++ b/pkg/api/buildstarted.go
@@ -112,12 +112,17 @@ func (e BuildStartedEvent) GetSchema() string {
 	return buildStartedSchemaFile
 }
 
-func newBuildStartedEvent() CDEvent {
-	return &BuildStartedEvent{
+func NewBuildStartedEvent() (*BuildStartedEvent, error) {
+	e := &BuildStartedEvent{
 		Context: Context{
 			Type:    BuildStartedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: BuildStartedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/changeabandoned.go
+++ b/pkg/api/changeabandoned.go
@@ -112,8 +112,8 @@ func (e ChangeAbandonedEvent) GetSchema() string {
 	return changeAbandonedSchemaFile
 }
 
-func newChangeAbandonedEvent() CDEvent {
-	return &ChangeAbandonedEvent{
+func NewChangeAbandonedEvent() (*ChangeAbandonedEvent, error) {
+	e := &ChangeAbandonedEvent{
 		Context: Context{
 			Type:    ChangeAbandonedEventV1,
 			Version: CDEventsSpecVersion,
@@ -124,4 +124,9 @@ func newChangeAbandonedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/changecreated.go
+++ b/pkg/api/changecreated.go
@@ -112,8 +112,8 @@ func (e ChangeCreatedEvent) GetSchema() string {
 	return changeCreatedSchemaFile
 }
 
-func newChangeCreatedEvent() CDEvent {
-	return &ChangeCreatedEvent{
+func NewChangeCreatedEvent() (*ChangeCreatedEvent, error) {
+	e := &ChangeCreatedEvent{
 		Context: Context{
 			Type:    ChangeCreatedEventV1,
 			Version: CDEventsSpecVersion,
@@ -124,4 +124,9 @@ func newChangeCreatedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/changemerged.go
+++ b/pkg/api/changemerged.go
@@ -112,8 +112,8 @@ func (e ChangeMergedEvent) GetSchema() string {
 	return changeMergedSchemaFile
 }
 
-func newChangeMergedEvent() CDEvent {
-	return &ChangeMergedEvent{
+func NewChangeMergedEvent() (*ChangeMergedEvent, error) {
+	e := &ChangeMergedEvent{
 		Context: Context{
 			Type:    ChangeMergedEventV1,
 			Version: CDEventsSpecVersion,
@@ -124,4 +124,9 @@ func newChangeMergedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/changereviewed.go
+++ b/pkg/api/changereviewed.go
@@ -112,8 +112,8 @@ func (e ChangeReviewedEvent) GetSchema() string {
 	return changeReviewedSchemaFile
 }
 
-func newChangeReviewedEvent() CDEvent {
-	return &ChangeReviewedEvent{
+func NewChangeReviewedEvent() (*ChangeReviewedEvent, error) {
+	e := &ChangeReviewedEvent{
 		Context: Context{
 			Type:    ChangeReviewedEventV1,
 			Version: CDEventsSpecVersion,
@@ -124,4 +124,9 @@ func newChangeReviewedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/changeupdated.go
+++ b/pkg/api/changeupdated.go
@@ -112,8 +112,8 @@ func (e ChangeUpdatedEvent) GetSchema() string {
 	return changeUpdatedSchemaFile
 }
 
-func newChangeUpdatedEvent() CDEvent {
-	return &ChangeUpdatedEvent{
+func NewChangeUpdatedEvent() (*ChangeUpdatedEvent, error) {
+	e := &ChangeUpdatedEvent{
 		Context: Context{
 			Type:    ChangeUpdatedEventV1,
 			Version: CDEventsSpecVersion,
@@ -124,4 +124,9 @@ func newChangeUpdatedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/environmentcreated.go
+++ b/pkg/api/environmentcreated.go
@@ -112,12 +112,17 @@ func (e EnvironmentCreatedEvent) GetSchema() string {
 	return environmentCreatedSchemaFile
 }
 
-func newEnvironmentCreatedEvent() CDEvent {
-	return &EnvironmentCreatedEvent{
+func NewEnvironmentCreatedEvent() (*EnvironmentCreatedEvent, error) {
+	e := &EnvironmentCreatedEvent{
 		Context: Context{
 			Type:    EnvironmentCreatedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: EnvironmentCreatedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/environmentdeleted.go
+++ b/pkg/api/environmentdeleted.go
@@ -112,12 +112,17 @@ func (e EnvironmentDeletedEvent) GetSchema() string {
 	return environmentDeletedSchemaFile
 }
 
-func newEnvironmentDeletedEvent() CDEvent {
-	return &EnvironmentDeletedEvent{
+func NewEnvironmentDeletedEvent() (*EnvironmentDeletedEvent, error) {
+	e := &EnvironmentDeletedEvent{
 		Context: Context{
 			Type:    EnvironmentDeletedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: EnvironmentDeletedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/environmentmodified.go
+++ b/pkg/api/environmentmodified.go
@@ -112,12 +112,17 @@ func (e EnvironmentModifiedEvent) GetSchema() string {
 	return environmentModifiedSchemaFile
 }
 
-func newEnvironmentModifiedEvent() CDEvent {
-	return &EnvironmentModifiedEvent{
+func NewEnvironmentModifiedEvent() (*EnvironmentModifiedEvent, error) {
+	e := &EnvironmentModifiedEvent{
 		Context: Context{
 			Type:    EnvironmentModifiedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: EnvironmentModifiedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/factory.go
+++ b/pkg/api/factory.go
@@ -38,107 +38,76 @@ func initCDEvent(e CDEvent) (CDEvent, error) {
 	return e, nil
 }
 
+// NewCDEvent produces a CDEvent by type
+// This function can be used by users but it's meant mainly for testing purposes
 func NewCDEvent(eventType CDEventType) (CDEvent, error) {
 	switch eventType {
 	case PipelineRunQueuedEventV1:
-		e := newPipelineRunQueuedEvent()
-		return initCDEvent(e)
+		return NewPipelineRunQueuedEvent()
 	case PipelineRunStartedEventV1:
-		e := newPipelineRunStartedEvent()
-		return initCDEvent(e)
+		return NewPipelineRunStartedEvent()
 	case PipelineRunFinishedEventV1:
-		e := newPipelineRunFinishedEvent()
-		return initCDEvent(e)
+		return NewPipelineRunFinishedEvent()
 	case TaskRunStartedEventV1:
-		e := newTaskRunStartedEvent()
-		return initCDEvent(e)
+		return NewTaskRunStartedEvent()
 	case TaskRunFinishedEventV1:
-		e := newTaskRunFinishedEvent()
-		return initCDEvent(e)
+		return NewTaskRunFinishedEvent()
 	// case RepositoryCreatedEventV1:
-	// 	e := newRepositoryCreatedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewRepositoryCreatedEvent()
 	// case RepositoryModifiedEventV1:
-	// 	e := newRepositoryModifiedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewRepositoryModifiedEvent()
 	// case RepositoryDeletedEventV1:
-	// 	e := newRepositoryDeletedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewRepositoryDeletedEvent()
 	// case BranchCreatedEventV1:
-	// 	e := newBranchCreatedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewBranchCreatedEvent()
 	// case BranchDeletedEventV1:
-	// 	e := newBranchDeletedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewBranchDeletedEvent()
 	case ChangeCreatedEventV1:
-		e := newChangeCreatedEvent()
-		return initCDEvent(e)
+		return NewChangeCreatedEvent()
 	case ChangeUpdatedEventV1:
-		e := newChangeUpdatedEvent()
-		return initCDEvent(e)
+		return NewChangeUpdatedEvent()
 	case ChangeReviewedEventV1:
-		e := newChangeReviewedEvent()
-		return initCDEvent(e)
+		return NewChangeReviewedEvent()
 	case ChangeMergedEventV1:
-		e := newChangeMergedEvent()
-		return initCDEvent(e)
+		return NewChangeMergedEvent()
 	case ChangeAbandonedEventV1:
-		e := newChangeAbandonedEvent()
-		return initCDEvent(e)
+		return NewChangeAbandonedEvent()
 	// case BuildQueuedEventV1:
-	// 	e := newBuildQueuedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewBuildQueuedEvent()
 	// case BuildStartedEventV1:
-	// 	e := newBuildStartedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewBuildStartedEvent()
 	// case BuildFinishedEventV1:
-	// 	e := newBuildFinishedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewBuildFinishedEvent()
 	// case TestCaseQueuedEventV1:
-	// 	e := newTestCaseQueuedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewTestCaseQueuedEvent()
 	// case TestCaseStartedEventV1:
-	// 	e := newTestCaseStartedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewTestCaseStartedEvent()
 	// case TestCaseFinishedEventV1:
-	// 	e := newTestCaseFinishedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewTestCaseFinishedEvent()
 	// case TestSuiteStartedEventV1:
-	// 	e := newTestSuiteStartedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewTestSuiteStartedEvent()
 	// case TestSuiteFinishedEventV1:
-	// 	e := newTestSuiteFinishedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewTestSuiteFinishedEvent()
 	// case ArtifactPackagedEventV1:
-	// 	e := newArtifactPackagedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewArtifactPackagedEvent()
 	// case ArtifactPublishedEventV1:
-	// 	e := newArtifactPublishedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewArtifactPublishedEvent()
 	// case EnvironmentCreatedEventV1:
-	// 	e := newEnvironmentCreatedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewEnvironmentCreatedEvent()
 	// case EnvironmentModifiedEventV1:
-	// 	e := newEnvironmentModifiedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewEnvironmentModifiedEvent()
 	// case EnvironmentDeletedEventV1:
-	// 	e := newEnvironmentDeletedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewEnvironmentDeletedEvent()
 	// case ServiceDeployedEventV1:
-	// 	e := newServiceDeployedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewServiceDeployedEvent()
 	// case ServiceUpgradedEventV1:
-	// 	e := newServiceUpgradedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewServiceUpgradedEvent()
 	// case ServiceRolledbackEventV1:
-	// 	e := newServiceRolledbackEvent()
-	// 	return initCDEvent(e)
+	// 	return NewServiceRolledbackEvent()
 	// case ServiceRemovedEventV1:
-	// 	e := newServiceRemovedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewServiceRemovedEvent()
 	// case ServicePublishedEventV1:
-	// 	e := newServicePublishedEvent()
-	// 	return initCDEvent(e)
+	// 	return NewServicePublishedEvent()
 	default:
 		return nil, fmt.Errorf("event %v not supported", eventType)
 	}

--- a/pkg/api/pipelinerunfinished.go
+++ b/pkg/api/pipelinerunfinished.go
@@ -159,8 +159,8 @@ func (e PipelineRunFinishedEvent) GetSchema() string {
 	return pipelineRunFinishedSchemaFile
 }
 
-func newPipelineRunFinishedEvent() CDEvent {
-	return &PipelineRunFinishedEvent{
+func NewPipelineRunFinishedEvent() (*PipelineRunFinishedEvent, error) {
+	e := &PipelineRunFinishedEvent{
 		Context: Context{
 			Type:    PipelineRunFinishedEventV1,
 			Version: CDEventsSpecVersion,
@@ -171,4 +171,9 @@ func newPipelineRunFinishedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/pipelinerunqueued.go
+++ b/pkg/api/pipelinerunqueued.go
@@ -129,8 +129,8 @@ func (e PipelineRunQueuedEvent) GetSchema() string {
 	return pipelineRunQueuedSchemaFile
 }
 
-func newPipelineRunQueuedEvent() CDEvent {
-	return &PipelineRunQueuedEvent{
+func NewPipelineRunQueuedEvent() (*PipelineRunQueuedEvent, error) {
+	e := &PipelineRunQueuedEvent{
 		Context: Context{
 			Type:    PipelineRunQueuedEventV1,
 			Version: CDEventsSpecVersion,
@@ -141,4 +141,9 @@ func newPipelineRunQueuedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/pipelinerunstarted.go
+++ b/pkg/api/pipelinerunstarted.go
@@ -129,8 +129,8 @@ func (e PipelineRunStartedEvent) GetSchema() string {
 	return pipelineRunStartedSchemaFile
 }
 
-func newPipelineRunStartedEvent() CDEvent {
-	return &PipelineRunStartedEvent{
+func NewPipelineRunStartedEvent() (*PipelineRunStartedEvent, error) {
+	e := &PipelineRunStartedEvent{
 		Context: Context{
 			Type:    PipelineRunStartedEventV1,
 			Version: CDEventsSpecVersion,
@@ -141,4 +141,9 @@ func newPipelineRunStartedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/repositorycreated.go
+++ b/pkg/api/repositorycreated.go
@@ -112,12 +112,17 @@ func (e RepositoryCreatedEvent) GetSchema() string {
 	return repositoryCreatedSchemaFile
 }
 
-func newRepositoryCreatedEvent() CDEvent {
-	return &RepositoryCreatedEvent{
+func NewRepositoryCreatedEvent() (*RepositoryCreatedEvent, error) {
+	e := &RepositoryCreatedEvent{
 		Context: Context{
 			Type:    RepositoryCreatedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: RepositoryCreatedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/repositorydeleted.go
+++ b/pkg/api/repositorydeleted.go
@@ -112,12 +112,17 @@ func (e RepositoryDeletedEvent) GetSchema() string {
 	return repositoryDeletedSchemaFile
 }
 
-func newRepositoryDeletedEvent() CDEvent {
-	return &RepositoryDeletedEvent{
+func NewRepositoryDeletedEvent() (*RepositoryDeletedEvent, error) {
+	e := &RepositoryDeletedEvent{
 		Context: Context{
 			Type:    RepositoryDeletedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: RepositoryDeletedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/repositorymodified.go
+++ b/pkg/api/repositorymodified.go
@@ -112,12 +112,17 @@ func (e RepositoryModifiedEvent) GetSchema() string {
 	return repositoryModifiedSchemaFile
 }
 
-func newRepositoryModifiedEvent() CDEvent {
-	return &RepositoryModifiedEvent{
+func NewRepositoryModifiedEvent() (*RepositoryModifiedEvent, error) {
+	e := &RepositoryModifiedEvent{
 		Context: Context{
 			Type:    RepositoryModifiedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: RepositoryModifiedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/servicedeployed.go
+++ b/pkg/api/servicedeployed.go
@@ -112,12 +112,17 @@ func (e ServiceDeployedEvent) GetSchema() string {
 	return serviceDeployedSchemaFile
 }
 
-func newServiceDeployedEvent() CDEvent {
-	return &ServiceDeployedEvent{
+func NewServiceDeployedEvent() (*ServiceDeployedEvent, error) {
+	e := &ServiceDeployedEvent{
 		Context: Context{
 			Type:    ServiceDeployedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: ServiceDeployedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/servicepublished.go
+++ b/pkg/api/servicepublished.go
@@ -112,12 +112,17 @@ func (e ServicePublishedEvent) GetSchema() string {
 	return servicePublishedSchemaFile
 }
 
-func newServicePublishedEvent() CDEvent {
-	return &ServicePublishedEvent{
+func NewServicePublishedEvent() (*ServicePublishedEvent, error) {
+	e := &ServicePublishedEvent{
 		Context: Context{
 			Type:    ServicePublishedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: ServicePublishedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/serviceremoved.go
+++ b/pkg/api/serviceremoved.go
@@ -112,12 +112,17 @@ func (e ServiceRemovedEvent) GetSchema() string {
 	return serviceRemovedSchemaFile
 }
 
-func newServiceRemovedEvent() CDEvent {
-	return &ServiceRemovedEvent{
+func NewServiceRemovedEvent() (*ServiceRemovedEvent, error) {
+	e := &ServiceRemovedEvent{
 		Context: Context{
 			Type:    ServiceRemovedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: ServiceRemovedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/servicerolledback.go
+++ b/pkg/api/servicerolledback.go
@@ -112,12 +112,17 @@ func (e ServiceRolledbackEvent) GetSchema() string {
 	return serviceRolledbackSchemaFile
 }
 
-func newServiceRolledbackEvent() CDEvent {
-	return &ServiceRolledbackEvent{
+func NewServiceRolledbackEvent() (*ServiceRolledbackEvent, error) {
+	e := &ServiceRolledbackEvent{
 		Context: Context{
 			Type:    ServiceRolledbackEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: ServiceRolledbackSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/serviceupgraded.go
+++ b/pkg/api/serviceupgraded.go
@@ -112,12 +112,17 @@ func (e ServiceUpgradedEvent) GetSchema() string {
 	return serviceUpgradedSchemaFile
 }
 
-func newServiceUpgradedEvent() CDEvent {
-	return &ServiceUpgradedEvent{
+func NewServiceUpgradedEvent() (*ServiceUpgradedEvent, error) {
+	e := &ServiceUpgradedEvent{
 		Context: Context{
 			Type:    ServiceUpgradedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: ServiceUpgradedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/taskrunfinished.go
+++ b/pkg/api/taskrunfinished.go
@@ -165,8 +165,8 @@ func (e TaskRunFinishedEvent) GetSchema() string {
 	return taskRunFinishedSchemaFile
 }
 
-func newTaskRunFinishedEvent() CDEvent {
-	return &TaskRunFinishedEvent{
+func NewTaskRunFinishedEvent() (*TaskRunFinishedEvent, error) {
+	e := &TaskRunFinishedEvent{
 		Context: Context{
 			Type:    TaskRunFinishedEventV1,
 			Version: CDEventsSpecVersion,
@@ -177,4 +177,9 @@ func newTaskRunFinishedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/taskrunstarted.go
+++ b/pkg/api/taskrunstarted.go
@@ -136,8 +136,8 @@ func (e TaskRunStartedEvent) GetSchema() string {
 	return taskRunStartedSchemaFile
 }
 
-func newTaskRunStartedEvent() CDEvent {
-	return &TaskRunStartedEvent{
+func NewTaskRunStartedEvent() (*TaskRunStartedEvent, error) {
+	e := &TaskRunStartedEvent{
 		Context: Context{
 			Type:    TaskRunStartedEventV1,
 			Version: CDEventsSpecVersion,
@@ -148,4 +148,9 @@ func newTaskRunStartedEvent() CDEvent {
 			},
 		},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/testcasefinished.go
+++ b/pkg/api/testcasefinished.go
@@ -112,12 +112,17 @@ func (e TestCaseFinishedEvent) GetSchema() string {
 	return testCaseFinishedSchemaFile
 }
 
-func newTestCaseFinishedEvent() CDEvent {
-	return &TestCaseFinishedEvent{
+func NewTestCaseFinishedEvent() (*TestCaseFinishedEvent, error) {
+	e := &TestCaseFinishedEvent{
 		Context: Context{
 			Type:    TestCaseFinishedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: TestCaseFinishedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/testcasequeued.go
+++ b/pkg/api/testcasequeued.go
@@ -112,12 +112,17 @@ func (e TestCaseQueuedEvent) GetSchema() string {
 	return testCaseQueuedSchemaFile
 }
 
-func newTestCaseQueuedEvent() CDEvent {
-	return &TestCaseQueuedEvent{
+func NewTestCaseQueuedEvent() (*TestCaseQueuedEvent, error) {
+	e := &TestCaseQueuedEvent{
 		Context: Context{
 			Type:    TestCaseQueuedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: TestCaseQueuedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/testcasestarted.go
+++ b/pkg/api/testcasestarted.go
@@ -112,12 +112,17 @@ func (e TestCaseStartedEvent) GetSchema() string {
 	return testCaseStartedSchemaFile
 }
 
-func newTestCaseStartedEvent() CDEvent {
-	return &TestCaseStartedEvent{
+func NewTestCaseStartedEvent() (*TestCaseStartedEvent, error) {
+	e := &TestCaseStartedEvent{
 		Context: Context{
 			Type:    TestCaseStartedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: TestCaseStartedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/testsuitefinished.go
+++ b/pkg/api/testsuitefinished.go
@@ -112,12 +112,17 @@ func (e TestSuiteFinishedEvent) GetSchema() string {
 	return testSuiteFinishedSchemaFile
 }
 
-func newTestSuiteFinishedEvent() CDEvent {
-	return &TestSuiteFinishedEvent{
+func NewTestSuiteFinishedEvent() (*TestSuiteFinishedEvent, error) {
+	e := &TestSuiteFinishedEvent{
 		Context: Context{
 			Type:    TestSuiteFinishedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: TestSuiteFinishedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }

--- a/pkg/api/testsuitestarted.go
+++ b/pkg/api/testsuitestarted.go
@@ -112,12 +112,17 @@ func (e TestSuiteStartedEvent) GetSchema() string {
 	return testSuiteStartedSchemaFile
 }
 
-func newTestSuiteStartedEvent() CDEvent {
-	return &TestSuiteStartedEvent{
+func NewTestSuiteStartedEvent() (*TestSuiteStartedEvent, error) {
+	e := &TestSuiteStartedEvent{
 		Context: Context{
 			Type:    TestSuiteStartedEventV1,
 			Version: CDEventsSpecVersion,
 		},
 		Subject: TestSuiteStartedSubject{},
 	}
+	_, err := initCDEvent(e)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
 }


### PR DESCRIPTION
Simplify the SDK user experience by exposing methods to create
directly specific events, rather then having a single method
that creates events by type and requires type assertions to
access event specific attributes.

I preserved the factory method that creates the events by type
for now as it's convenient for testing all the various events
in one unit test.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

/cc @xibz