### PR TITLE
Add Github Action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    types:
+      - "opened"
+      - "synchronize"
+    paths-ignore:
+      - "README.md"
+      - ".gitignore"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/go
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+    - name: Format check
+      run: make fmt
+    - name: Linting check
+      run: make lint
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/go
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+    - name: Test
+      run: make test


### PR DESCRIPTION
Add Github action the runs fmt, test, lint from the makefile on PR

Closes issue: [#2](https://github.com/cdevents/sdk-go/issues/2)

Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>