### PR TITLE
Add custom data to the SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ REPO := sdk-go
 ORG_REPO := $(ORG)/$(REPO)
 RELEASE_ORG_REPO := $(ORG_REPO)
 ROOT_PACKAGE := github.com/$(ORG_REPO)
-GO_VERSION := 1.18
+GO_VERSION := 1.19
 GO_DEPENDENCIES := $(call rwildcard,pkg/,*.go) $(call rwildcard,cmd/,*.go)
 
 BRANCH     := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null  || echo 'unknown')

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -11,7 +11,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if ! [ -x "$(command -v golangci-lint)" ]; then
 	echo "Installing GolangCI-Lint"
-	${DIR}/install_golint.sh -b $GOPATH/bin v1.29.0
+	${DIR}/install_golint.sh -b $GOPATH/bin v1.49.0
 fi
 
 export GO111MODULE=on

--- a/jsonschema/artifactpackaged.json
+++ b/jsonschema/artifactpackaged.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/artifact-packaged-event",
+  "$id": "https://cdevents.dev/draft/schema/artifact-packaged-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/artifactpublished.json
+++ b/jsonschema/artifactpublished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/artifact-published-event",
+  "$id": "https://cdevents.dev/draft/schema/artifact-published-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/branchcreated.json
+++ b/jsonschema/branchcreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/branch-created-event",
+  "$id": "https://cdevents.dev/draft/schema/branch-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/branchdeleted.json
+++ b/jsonschema/branchdeleted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/branch-deleted-event",
+  "$id": "https://cdevents.dev/draft/schema/branch-deleted-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/buildfinished.json
+++ b/jsonschema/buildfinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/build-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -68,6 +68,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/buildqueued.json
+++ b/jsonschema/buildqueued.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-queued-event",
+  "$id": "https://cdevents.dev/draft/schema/build-queued-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/buildstarted.json
+++ b/jsonschema/buildstarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-started-event",
+  "$id": "https://cdevents.dev/draft/schema/build-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/changeabandoned.json
+++ b/jsonschema/changeabandoned.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-abandoned-event",
+  "$id": "https://cdevents.dev/draft/schema/change-abandoned-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/changecreated.json
+++ b/jsonschema/changecreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-created-event",
+  "$id": "https://cdevents.dev/draft/schema/change-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/changemerged.json
+++ b/jsonschema/changemerged.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-merged-event",
+  "$id": "https://cdevents.dev/draft/schema/change-merged-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/changereviewed.json
+++ b/jsonschema/changereviewed.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-reviewed-event",
+  "$id": "https://cdevents.dev/draft/schema/change-reviewed-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/changeupdated.json
+++ b/jsonschema/changeupdated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-updated-event",
+  "$id": "https://cdevents.dev/draft/schema/change-updated-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/environmentcreated.json
+++ b/jsonschema/environmentcreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-created-event",
+  "$id": "https://cdevents.dev/draft/schema/environment-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -71,6 +71,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/environmentdeleted.json
+++ b/jsonschema/environmentdeleted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-deleted-event",
+  "$id": "https://cdevents.dev/draft/schema/environment-deleted-event",
   "properties": {
     "context": {
       "properties": {
@@ -68,6 +68,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/environmentmodified.json
+++ b/jsonschema/environmentmodified.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-modified-event",
+  "$id": "https://cdevents.dev/draft/schema/environment-modified-event",
   "properties": {
     "context": {
       "properties": {
@@ -71,6 +71,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/pipelinerunfinished.json
+++ b/jsonschema/pipelinerunfinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/pipeline-run-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/pipelinerunqueued.json
+++ b/jsonschema/pipelinerunqueued.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-queued-event",
+  "$id": "https://cdevents.dev/draft/schema/pipeline-run-queued-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/pipelinerunstarted.json
+++ b/jsonschema/pipelinerunstarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-started-event",
+  "$id": "https://cdevents.dev/draft/schema/pipeline-run-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -75,6 +75,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/repositorycreated.json
+++ b/jsonschema/repositorycreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-created-event",
+  "$id": "https://cdevents.dev/draft/schema/repository-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -83,6 +83,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/repositorydeleted.json
+++ b/jsonschema/repositorydeleted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-deleted-event",
+  "$id": "https://cdevents.dev/draft/schema/repository-deleted-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/repositorymodified.json
+++ b/jsonschema/repositorymodified.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-modified-event",
+  "$id": "https://cdevents.dev/draft/schema/repository-modified-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/servicedeployed.json
+++ b/jsonschema/servicedeployed.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-deployed-event",
+  "$id": "https://cdevents.dev/draft/schema/service-deployed-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/servicepublished.json
+++ b/jsonschema/servicepublished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-published-event",
+  "$id": "https://cdevents.dev/draft/schema/service-published-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/serviceremoved.json
+++ b/jsonschema/serviceremoved.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-removed-event",
+  "$id": "https://cdevents.dev/draft/schema/service-removed-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/servicerolledback.json
+++ b/jsonschema/servicerolledback.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-rolledback-event",
+  "$id": "https://cdevents.dev/draft/schema/service-rolledback-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/serviceupgraded.json
+++ b/jsonschema/serviceupgraded.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-upgraded-event",
+  "$id": "https://cdevents.dev/draft/schema/service-upgraded-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/taskrunfinished.json
+++ b/jsonschema/taskrunfinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/task-run-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/task-run-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -93,6 +93,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/taskrunstarted.json
+++ b/jsonschema/taskrunstarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/task-run-started-event",
+  "$id": "https://cdevents.dev/draft/schema/task-run-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -87,6 +87,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/testcasefinished.json
+++ b/jsonschema/testcasefinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/test-case-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/testcasequeued.json
+++ b/jsonschema/testcasequeued.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-queued-event",
+  "$id": "https://cdevents.dev/draft/schema/test-case-queued-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/testcasestarted.json
+++ b/jsonschema/testcasestarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-started-event",
+  "$id": "https://cdevents.dev/draft/schema/test-case-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/testsuitefinished.json
+++ b/jsonschema/testsuitefinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-suite-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/test-suite-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/jsonschema/testsuitestarted.json
+++ b/jsonschema/testsuitestarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-suite-started-event",
+  "$id": "https://cdevents.dev/draft/schema/test-suite-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/main.go
+++ b/main.go
@@ -73,8 +73,7 @@ func panicOnError(err error) {
 
 func main() {
 	// Setup a reflector
-	id := jsonschema.EmptyID
-	id.Add(fmt.Sprintf("https://cdevents.dev/%s/schema", api.CDEventsSpecVersion))
+	id := jsonschema.ID(fmt.Sprintf("https://cdevents.dev/%s/schema", api.CDEventsSpecVersion))
 	reflector := jsonschema.Reflector{
 		BaseSchemaID:   id,
 		DoNotReference: true,

--- a/pkg/api/artifactpackaged.go
+++ b/pkg/api/artifactpackaged.go
@@ -46,6 +46,7 @@ func (sc ArtifactPackagedSubject) GetSubjectType() SubjectType {
 type ArtifactPackagedEvent struct {
 	Context Context                 `json:"context"`
 	Subject ArtifactPackagedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e ArtifactPackagedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ArtifactPackagedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ArtifactPackagedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ArtifactPackagedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ArtifactPackagedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *ArtifactPackagedEvent) SetSubjectId(subjectId string) {
 
 func (e *ArtifactPackagedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ArtifactPackagedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ArtifactPackagedEvent) GetSchema() string {

--- a/pkg/api/artifactpublished.go
+++ b/pkg/api/artifactpublished.go
@@ -46,6 +46,7 @@ func (sc ArtifactPublishedSubject) GetSubjectType() SubjectType {
 type ArtifactPublishedEvent struct {
 	Context Context                  `json:"context"`
 	Subject ArtifactPublishedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e ArtifactPublishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ArtifactPublishedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ArtifactPublishedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ArtifactPublishedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ArtifactPublishedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *ArtifactPublishedEvent) SetSubjectId(subjectId string) {
 
 func (e *ArtifactPublishedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ArtifactPublishedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ArtifactPublishedEvent) GetSchema() string {

--- a/pkg/api/bindings.go
+++ b/pkg/api/bindings.go
@@ -77,7 +77,7 @@ func init() {
 
 	// Setup a reflector
 	id := schemaproducer.EmptyID
-	id.Add(fmt.Sprintf("https://cdevents.dev/%s/schema", CDEventsSpecVersion))
+	id = id.Add(fmt.Sprintf("https://cdevents.dev/%s/schema", CDEventsSpecVersion))
 	reflector := schemaproducer.Reflector{
 		BaseSchemaID:   id,
 		DoNotReference: true,

--- a/pkg/api/branchcreated.go
+++ b/pkg/api/branchcreated.go
@@ -46,6 +46,7 @@ func (sc BranchCreatedSubject) GetSubjectType() SubjectType {
 type BranchCreatedEvent struct {
 	Context Context              `json:"context"`
 	Subject BranchCreatedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e BranchCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e BranchCreatedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e BranchCreatedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e BranchCreatedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *BranchCreatedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *BranchCreatedEvent) SetSubjectId(subjectId string) {
 
 func (e *BranchCreatedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *BranchCreatedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e BranchCreatedEvent) GetSchema() string {

--- a/pkg/api/branchdeleted.go
+++ b/pkg/api/branchdeleted.go
@@ -46,6 +46,7 @@ func (sc BranchDeletedSubject) GetSubjectType() SubjectType {
 type BranchDeletedEvent struct {
 	Context Context              `json:"context"`
 	Subject BranchDeletedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e BranchDeletedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e BranchDeletedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e BranchDeletedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e BranchDeletedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *BranchDeletedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *BranchDeletedEvent) SetSubjectId(subjectId string) {
 
 func (e *BranchDeletedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *BranchDeletedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e BranchDeletedEvent) GetSchema() string {

--- a/pkg/api/buildfinished.go
+++ b/pkg/api/buildfinished.go
@@ -50,6 +50,7 @@ func (sc BuildFinishedSubject) GetSubjectType() SubjectType {
 type BuildFinishedEvent struct {
 	Context Context              `json:"context"`
 	Subject BuildFinishedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -86,6 +87,18 @@ func (e BuildFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e BuildFinishedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e BuildFinishedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e BuildFinishedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *BuildFinishedEvent) SetId(id string) {
@@ -110,6 +123,15 @@ func (e *BuildFinishedEvent) SetSubjectId(subjectId string) {
 
 func (e *BuildFinishedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *BuildFinishedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e BuildFinishedEvent) GetSchema() string {

--- a/pkg/api/buildqueued.go
+++ b/pkg/api/buildqueued.go
@@ -46,6 +46,7 @@ func (sc BuildQueuedSubject) GetSubjectType() SubjectType {
 type BuildQueuedEvent struct {
 	Context Context            `json:"context"`
 	Subject BuildQueuedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e BuildQueuedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e BuildQueuedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e BuildQueuedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e BuildQueuedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *BuildQueuedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *BuildQueuedEvent) SetSubjectId(subjectId string) {
 
 func (e *BuildQueuedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *BuildQueuedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e BuildQueuedEvent) GetSchema() string {

--- a/pkg/api/buildstarted.go
+++ b/pkg/api/buildstarted.go
@@ -46,6 +46,7 @@ func (sc BuildStartedSubject) GetSubjectType() SubjectType {
 type BuildStartedEvent struct {
 	Context Context             `json:"context"`
 	Subject BuildStartedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e BuildStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e BuildStartedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e BuildStartedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e BuildStartedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *BuildStartedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *BuildStartedEvent) SetSubjectId(subjectId string) {
 
 func (e *BuildStartedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *BuildStartedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e BuildStartedEvent) GetSchema() string {

--- a/pkg/api/changeabandoned.go
+++ b/pkg/api/changeabandoned.go
@@ -46,6 +46,7 @@ func (sc ChangeAbandonedSubject) GetSubjectType() SubjectType {
 type ChangeAbandonedEvent struct {
 	Context Context                `json:"context"`
 	Subject ChangeAbandonedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e ChangeAbandonedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ChangeAbandonedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ChangeAbandonedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeAbandonedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ChangeAbandonedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *ChangeAbandonedEvent) SetSubjectId(subjectId string) {
 
 func (e *ChangeAbandonedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ChangeAbandonedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ChangeAbandonedEvent) GetSchema() string {

--- a/pkg/api/changecreated.go
+++ b/pkg/api/changecreated.go
@@ -46,6 +46,7 @@ func (sc ChangeCreatedSubject) GetSubjectType() SubjectType {
 type ChangeCreatedEvent struct {
 	Context Context              `json:"context"`
 	Subject ChangeCreatedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e ChangeCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ChangeCreatedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ChangeCreatedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeCreatedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ChangeCreatedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *ChangeCreatedEvent) SetSubjectId(subjectId string) {
 
 func (e *ChangeCreatedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ChangeCreatedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ChangeCreatedEvent) GetSchema() string {

--- a/pkg/api/changemerged.go
+++ b/pkg/api/changemerged.go
@@ -46,6 +46,7 @@ func (sc ChangeMergedSubject) GetSubjectType() SubjectType {
 type ChangeMergedEvent struct {
 	Context Context             `json:"context"`
 	Subject ChangeMergedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e ChangeMergedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ChangeMergedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ChangeMergedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeMergedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ChangeMergedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *ChangeMergedEvent) SetSubjectId(subjectId string) {
 
 func (e *ChangeMergedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ChangeMergedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ChangeMergedEvent) GetSchema() string {

--- a/pkg/api/changereviewed.go
+++ b/pkg/api/changereviewed.go
@@ -46,6 +46,7 @@ func (sc ChangeReviewedSubject) GetSubjectType() SubjectType {
 type ChangeReviewedEvent struct {
 	Context Context               `json:"context"`
 	Subject ChangeReviewedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e ChangeReviewedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ChangeReviewedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ChangeReviewedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeReviewedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ChangeReviewedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *ChangeReviewedEvent) SetSubjectId(subjectId string) {
 
 func (e *ChangeReviewedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ChangeReviewedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ChangeReviewedEvent) GetSchema() string {

--- a/pkg/api/changeupdated.go
+++ b/pkg/api/changeupdated.go
@@ -46,6 +46,7 @@ func (sc ChangeUpdatedSubject) GetSubjectType() SubjectType {
 type ChangeUpdatedEvent struct {
 	Context Context              `json:"context"`
 	Subject ChangeUpdatedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e ChangeUpdatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ChangeUpdatedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ChangeUpdatedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeUpdatedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ChangeUpdatedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *ChangeUpdatedEvent) SetSubjectId(subjectId string) {
 
 func (e *ChangeUpdatedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ChangeUpdatedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ChangeUpdatedEvent) GetSchema() string {

--- a/pkg/api/environmentcreated.go
+++ b/pkg/api/environmentcreated.go
@@ -53,6 +53,7 @@ func (sc EnvironmentCreatedSubject) GetSubjectType() SubjectType {
 type EnvironmentCreatedEvent struct {
 	Context Context                   `json:"context"`
 	Subject EnvironmentCreatedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -89,6 +90,18 @@ func (e EnvironmentCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e EnvironmentCreatedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e EnvironmentCreatedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e EnvironmentCreatedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *EnvironmentCreatedEvent) SetId(id string) {
@@ -113,6 +126,15 @@ func (e *EnvironmentCreatedEvent) SetSubjectId(subjectId string) {
 
 func (e *EnvironmentCreatedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *EnvironmentCreatedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e EnvironmentCreatedEvent) GetSchema() string {

--- a/pkg/api/environmentdeleted.go
+++ b/pkg/api/environmentdeleted.go
@@ -50,6 +50,7 @@ func (sc EnvironmentDeletedSubject) GetSubjectType() SubjectType {
 type EnvironmentDeletedEvent struct {
 	Context Context                   `json:"context"`
 	Subject EnvironmentDeletedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -86,6 +87,18 @@ func (e EnvironmentDeletedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e EnvironmentDeletedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e EnvironmentDeletedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e EnvironmentDeletedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *EnvironmentDeletedEvent) SetId(id string) {
@@ -110,6 +123,15 @@ func (e *EnvironmentDeletedEvent) SetSubjectId(subjectId string) {
 
 func (e *EnvironmentDeletedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *EnvironmentDeletedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e EnvironmentDeletedEvent) GetSchema() string {

--- a/pkg/api/environmentmodified.go
+++ b/pkg/api/environmentmodified.go
@@ -53,6 +53,7 @@ func (sc EnvironmentModifiedSubject) GetSubjectType() SubjectType {
 type EnvironmentModifiedEvent struct {
 	Context Context                    `json:"context"`
 	Subject EnvironmentModifiedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -89,6 +90,18 @@ func (e EnvironmentModifiedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e EnvironmentModifiedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e EnvironmentModifiedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e EnvironmentModifiedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *EnvironmentModifiedEvent) SetId(id string) {
@@ -113,6 +126,15 @@ func (e *EnvironmentModifiedEvent) SetSubjectId(subjectId string) {
 
 func (e *EnvironmentModifiedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *EnvironmentModifiedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e EnvironmentModifiedEvent) GetSchema() string {

--- a/pkg/api/pipelinerunfinished.go
+++ b/pkg/api/pipelinerunfinished.go
@@ -75,6 +75,7 @@ func (sc PipelineRunFinishedSubject) GetSubjectType() SubjectType {
 type PipelineRunFinishedEvent struct {
 	Context Context                    `json:"context"`
 	Subject PipelineRunFinishedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -111,6 +112,18 @@ func (e PipelineRunFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e PipelineRunFinishedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e PipelineRunFinishedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e PipelineRunFinishedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 // TODO(afrittoli) Add stricter validation where relevant
 
@@ -136,6 +149,15 @@ func (e *PipelineRunFinishedEvent) SetSubjectId(subjectId string) {
 
 func (e *PipelineRunFinishedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *PipelineRunFinishedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 // Subject field setters

--- a/pkg/api/pipelinerunqueued.go
+++ b/pkg/api/pipelinerunqueued.go
@@ -53,6 +53,7 @@ func (sc PipelineRunQueuedSubject) GetSubjectType() SubjectType {
 type PipelineRunQueuedEvent struct {
 	Context Context                  `json:"context"`
 	Subject PipelineRunQueuedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -89,6 +90,18 @@ func (e PipelineRunQueuedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e PipelineRunQueuedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e PipelineRunQueuedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e PipelineRunQueuedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 // TODO(afrittoli) Add stricter validation where relevant
 
@@ -114,6 +127,15 @@ func (e *PipelineRunQueuedEvent) SetSubjectId(subjectId string) {
 
 func (e *PipelineRunQueuedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *PipelineRunQueuedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 // Subject field setters

--- a/pkg/api/pipelinerunstarted.go
+++ b/pkg/api/pipelinerunstarted.go
@@ -53,6 +53,7 @@ func (sc PipelineRunStartedSubject) GetSubjectType() SubjectType {
 type PipelineRunStartedEvent struct {
 	Context Context                   `json:"context"`
 	Subject PipelineRunStartedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -89,6 +90,18 @@ func (e PipelineRunStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e PipelineRunStartedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e PipelineRunStartedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e PipelineRunStartedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 // TODO(afrittoli) Add stricter validation where relevant
 
@@ -114,6 +127,15 @@ func (e *PipelineRunStartedEvent) SetSubjectId(subjectId string) {
 
 func (e *PipelineRunStartedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *PipelineRunStartedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 // Subject field setters

--- a/pkg/api/repositorycreated.go
+++ b/pkg/api/repositorycreated.go
@@ -59,6 +59,7 @@ func (sc RepositoryCreatedSubject) GetSubjectType() SubjectType {
 type RepositoryCreatedEvent struct {
 	Context Context                  `json:"context"`
 	Subject RepositoryCreatedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -95,6 +96,18 @@ func (e RepositoryCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e RepositoryCreatedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e RepositoryCreatedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e RepositoryCreatedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *RepositoryCreatedEvent) SetId(id string) {
@@ -119,6 +132,15 @@ func (e *RepositoryCreatedEvent) SetSubjectId(subjectId string) {
 
 func (e *RepositoryCreatedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *RepositoryCreatedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e RepositoryCreatedEvent) GetSchema() string {

--- a/pkg/api/repositorydeleted.go
+++ b/pkg/api/repositorydeleted.go
@@ -59,6 +59,7 @@ func (sc RepositoryDeletedSubject) GetSubjectType() SubjectType {
 type RepositoryDeletedEvent struct {
 	Context Context                  `json:"context"`
 	Subject RepositoryDeletedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -95,6 +96,18 @@ func (e RepositoryDeletedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e RepositoryDeletedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e RepositoryDeletedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e RepositoryDeletedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *RepositoryDeletedEvent) SetId(id string) {
@@ -119,6 +132,15 @@ func (e *RepositoryDeletedEvent) SetSubjectId(subjectId string) {
 
 func (e *RepositoryDeletedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *RepositoryDeletedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e RepositoryDeletedEvent) GetSchema() string {

--- a/pkg/api/repositorymodified.go
+++ b/pkg/api/repositorymodified.go
@@ -59,6 +59,7 @@ func (sc RepositoryModifiedSubject) GetSubjectType() SubjectType {
 type RepositoryModifiedEvent struct {
 	Context Context                   `json:"context"`
 	Subject RepositoryModifiedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -95,6 +96,18 @@ func (e RepositoryModifiedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e RepositoryModifiedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e RepositoryModifiedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e RepositoryModifiedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *RepositoryModifiedEvent) SetId(id string) {
@@ -119,6 +132,15 @@ func (e *RepositoryModifiedEvent) SetSubjectId(subjectId string) {
 
 func (e *RepositoryModifiedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *RepositoryModifiedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e RepositoryModifiedEvent) GetSchema() string {

--- a/pkg/api/servicedeployed.go
+++ b/pkg/api/servicedeployed.go
@@ -50,6 +50,7 @@ func (sc ServiceDeployedSubject) GetSubjectType() SubjectType {
 type ServiceDeployedEvent struct {
 	Context Context                `json:"context"`
 	Subject ServiceDeployedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -86,6 +87,18 @@ func (e ServiceDeployedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ServiceDeployedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ServiceDeployedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceDeployedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ServiceDeployedEvent) SetId(id string) {
@@ -110,6 +123,15 @@ func (e *ServiceDeployedEvent) SetSubjectId(subjectId string) {
 
 func (e *ServiceDeployedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ServiceDeployedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ServiceDeployedEvent) GetSchema() string {

--- a/pkg/api/servicepublished.go
+++ b/pkg/api/servicepublished.go
@@ -50,6 +50,7 @@ func (sc ServicePublishedSubject) GetSubjectType() SubjectType {
 type ServicePublishedEvent struct {
 	Context Context                 `json:"context"`
 	Subject ServicePublishedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -86,6 +87,18 @@ func (e ServicePublishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ServicePublishedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ServicePublishedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ServicePublishedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ServicePublishedEvent) SetId(id string) {
@@ -110,6 +123,15 @@ func (e *ServicePublishedEvent) SetSubjectId(subjectId string) {
 
 func (e *ServicePublishedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ServicePublishedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ServicePublishedEvent) GetSchema() string {

--- a/pkg/api/serviceremoved.go
+++ b/pkg/api/serviceremoved.go
@@ -50,6 +50,7 @@ func (sc ServiceRemovedSubject) GetSubjectType() SubjectType {
 type ServiceRemovedEvent struct {
 	Context Context               `json:"context"`
 	Subject ServiceRemovedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -86,6 +87,18 @@ func (e ServiceRemovedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ServiceRemovedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ServiceRemovedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceRemovedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ServiceRemovedEvent) SetId(id string) {
@@ -110,6 +123,15 @@ func (e *ServiceRemovedEvent) SetSubjectId(subjectId string) {
 
 func (e *ServiceRemovedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ServiceRemovedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ServiceRemovedEvent) GetSchema() string {

--- a/pkg/api/servicerolledback.go
+++ b/pkg/api/servicerolledback.go
@@ -50,6 +50,7 @@ func (sc ServiceRolledbackSubject) GetSubjectType() SubjectType {
 type ServiceRolledbackEvent struct {
 	Context Context                  `json:"context"`
 	Subject ServiceRolledbackSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -86,6 +87,18 @@ func (e ServiceRolledbackEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ServiceRolledbackEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ServiceRolledbackEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceRolledbackEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ServiceRolledbackEvent) SetId(id string) {
@@ -110,6 +123,15 @@ func (e *ServiceRolledbackEvent) SetSubjectId(subjectId string) {
 
 func (e *ServiceRolledbackEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ServiceRolledbackEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ServiceRolledbackEvent) GetSchema() string {

--- a/pkg/api/serviceupgraded.go
+++ b/pkg/api/serviceupgraded.go
@@ -50,6 +50,7 @@ func (sc ServiceUpgradedSubject) GetSubjectType() SubjectType {
 type ServiceUpgradedEvent struct {
 	Context Context                `json:"context"`
 	Subject ServiceUpgradedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -86,6 +87,18 @@ func (e ServiceUpgradedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e ServiceUpgradedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e ServiceUpgradedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceUpgradedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *ServiceUpgradedEvent) SetId(id string) {
@@ -110,6 +123,15 @@ func (e *ServiceUpgradedEvent) SetSubjectId(subjectId string) {
 
 func (e *ServiceUpgradedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *ServiceUpgradedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e ServiceUpgradedEvent) GetSchema() string {

--- a/pkg/api/taskrunfinished.go
+++ b/pkg/api/taskrunfinished.go
@@ -77,6 +77,7 @@ func (sc TaskRunFinishedSubject) GetSubjectType() SubjectType {
 type TaskRunFinishedEvent struct {
 	Context Context                `json:"context"`
 	Subject TaskRunFinishedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -113,6 +114,18 @@ func (e TaskRunFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e TaskRunFinishedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e TaskRunFinishedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e TaskRunFinishedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 // TODO(afrittoli) Add stricter validation where relevant
 
@@ -138,6 +151,15 @@ func (e *TaskRunFinishedEvent) SetSubjectId(subjectId string) {
 
 func (e *TaskRunFinishedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *TaskRunFinishedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 // Subject field setters

--- a/pkg/api/taskrunstarted.go
+++ b/pkg/api/taskrunstarted.go
@@ -56,6 +56,7 @@ func (sc TaskRunStartedSubject) GetSubjectType() SubjectType {
 type TaskRunStartedEvent struct {
 	Context Context               `json:"context"`
 	Subject TaskRunStartedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -92,6 +93,18 @@ func (e TaskRunStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e TaskRunStartedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e TaskRunStartedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e TaskRunStartedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 // TODO(afrittoli) Add stricter validation where relevant
 
@@ -117,6 +130,15 @@ func (e *TaskRunStartedEvent) SetSubjectId(subjectId string) {
 
 func (e *TaskRunStartedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *TaskRunStartedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 // Subject field setters

--- a/pkg/api/testcasefinished.go
+++ b/pkg/api/testcasefinished.go
@@ -46,6 +46,7 @@ func (sc TestCaseFinishedSubject) GetSubjectType() SubjectType {
 type TestCaseFinishedEvent struct {
 	Context Context                 `json:"context"`
 	Subject TestCaseFinishedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e TestCaseFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e TestCaseFinishedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e TestCaseFinishedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e TestCaseFinishedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *TestCaseFinishedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *TestCaseFinishedEvent) SetSubjectId(subjectId string) {
 
 func (e *TestCaseFinishedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *TestCaseFinishedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e TestCaseFinishedEvent) GetSchema() string {

--- a/pkg/api/testcasequeued.go
+++ b/pkg/api/testcasequeued.go
@@ -46,6 +46,7 @@ func (sc TestCaseQueuedSubject) GetSubjectType() SubjectType {
 type TestCaseQueuedEvent struct {
 	Context Context               `json:"context"`
 	Subject TestCaseQueuedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e TestCaseQueuedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e TestCaseQueuedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e TestCaseQueuedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e TestCaseQueuedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *TestCaseQueuedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *TestCaseQueuedEvent) SetSubjectId(subjectId string) {
 
 func (e *TestCaseQueuedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *TestCaseQueuedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e TestCaseQueuedEvent) GetSchema() string {

--- a/pkg/api/testcasestarted.go
+++ b/pkg/api/testcasestarted.go
@@ -46,6 +46,7 @@ func (sc TestCaseStartedSubject) GetSubjectType() SubjectType {
 type TestCaseStartedEvent struct {
 	Context Context                `json:"context"`
 	Subject TestCaseStartedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e TestCaseStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e TestCaseStartedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e TestCaseStartedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e TestCaseStartedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *TestCaseStartedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *TestCaseStartedEvent) SetSubjectId(subjectId string) {
 
 func (e *TestCaseStartedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *TestCaseStartedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e TestCaseStartedEvent) GetSchema() string {

--- a/pkg/api/testsuitefinished.go
+++ b/pkg/api/testsuitefinished.go
@@ -46,6 +46,7 @@ func (sc TestSuiteFinishedSubject) GetSubjectType() SubjectType {
 type TestSuiteFinishedEvent struct {
 	Context Context                  `json:"context"`
 	Subject TestSuiteFinishedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e TestSuiteFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e TestSuiteFinishedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e TestSuiteFinishedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e TestSuiteFinishedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *TestSuiteFinishedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *TestSuiteFinishedEvent) SetSubjectId(subjectId string) {
 
 func (e *TestSuiteFinishedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *TestSuiteFinishedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e TestSuiteFinishedEvent) GetSchema() string {

--- a/pkg/api/testsuitestarted.go
+++ b/pkg/api/testsuitestarted.go
@@ -46,6 +46,7 @@ func (sc TestSuiteStartedSubject) GetSubjectType() SubjectType {
 type TestSuiteStartedEvent struct {
 	Context Context                 `json:"context"`
 	Subject TestSuiteStartedSubject `json:"subject"`
+	CDEventCustomData
 }
 
 // CDEventsReader implementation
@@ -82,6 +83,18 @@ func (e TestSuiteStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
+func (e TestSuiteStartedEvent) GetCustomData() []byte {
+	return e.CustomData
+}
+
+func (e TestSuiteStartedEvent) GetCustomDataAs(receiver interface{}) error {
+	return getCustomDataAs(e, receiver)
+}
+
+func (e TestSuiteStartedEvent) GetCustomDataContentType() string {
+	return e.CustomDataContentType
+}
+
 // CDEventsWriter implementation
 
 func (e *TestSuiteStartedEvent) SetId(id string) {
@@ -106,6 +119,15 @@ func (e *TestSuiteStartedEvent) SetSubjectId(subjectId string) {
 
 func (e *TestSuiteStartedEvent) SetSubjectSource(subjectSource string) {
 	e.Subject.Source = subjectSource
+}
+
+func (e *TestSuiteStartedEvent) SetCustomData(contentType string, data interface{}) error {
+	dataBytes, err := customDataBytes(contentType, data)
+	if err != nil {
+		return err
+	}
+	e.CustomData = dataBytes
+	return nil
 }
 
 func (e TestSuiteStartedEvent) GetSchema() string {

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 The CDEvents Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	testXmlString  = "<xml>testData</xml>"
+	testJsonString = "{\"testData\":\"testValue\"}"
+)
+
+var (
+	eventWithNonJsonCustomData *ArtifactPackagedEvent
+	eventWithJsonCustomData    *ArtifactPackagedEvent
+	testXmlBytesB64            []byte
+)
+
+func init() {
+
+	eventWithNonJsonCustomData, _ = NewArtifactPackagedEvent()
+	eventWithNonJsonCustomData.CustomDataContentType = "application/xml"
+	eventWithNonJsonCustomData.CustomData = []byte(testXmlString)
+
+	eventWithJsonCustomData, _ = NewArtifactPackagedEvent()
+	eventWithJsonCustomData.CustomDataContentType = "application/json"
+	eventWithJsonCustomData.CustomData = []byte(testJsonString)
+
+	testXmlBytes := []byte(testXmlString)
+	testXmlBytesB64 = make([]byte, base64.StdEncoding.EncodedLen(len(testXmlBytes)))
+	base64.StdEncoding.Encode(testXmlBytesB64, testXmlBytes)
+}
+
+type testType struct {
+	TestData string `json:"testData,omitempty"`
+}
+
+type testWrongType struct {
+	WrongTestData string `json:"wrongTestData,omitempty"`
+}
+
+func TestGetCustomDataAsNonJson(t *testing.T) {
+
+	receiver := &testType{}
+	expectedError := "cannot unmarshal content-type application/xml"
+
+	err := getCustomDataAs(eventWithNonJsonCustomData, receiver)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if d := cmp.Diff(expectedError, err.Error()); d != "" {
+		t.Errorf("args: diff(-want,+got):\n%s", d)
+	}
+}
+
+func TestGetCustomDataAsJson(t *testing.T) {
+
+	receiver := &testType{}
+	expectedValue := "testValue"
+
+	err := getCustomDataAs(eventWithJsonCustomData, receiver)
+	if err != nil {
+		t.Fatalf("did not expect an error, got %v", err)
+	}
+
+	if d := cmp.Diff(expectedValue, receiver.TestData); d != "" {
+		t.Errorf("args: diff(-want,+got):\n%s", d)
+	}
+}
+
+func TestGetCustomDataAsJsonInvalidReceiver(t *testing.T) {
+
+	receiver := &testWrongType{}
+	expectedReceiver := &testWrongType{}
+
+	err := getCustomDataAs(eventWithJsonCustomData, receiver)
+	if err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if d := cmp.Diff(*expectedReceiver, *receiver); d != "" {
+		t.Errorf("args: diff(-want,+got):\n%s", d)
+	}
+}
+
+func TestSetCustomData(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		contentType  string
+		data         interface{}
+		expectedData []byte
+	}{{
+		name:         "json, bytes",
+		contentType:  "application/json",
+		data:         []byte(testJsonString),
+		expectedData: []byte(testJsonString),
+	}, {
+		name:         "xml, bytes",
+		contentType:  "application/xml",
+		data:         []byte(testXmlString),
+		expectedData: testXmlBytesB64,
+	}, {
+		name:         "json, interface",
+		contentType:  "application/json",
+		data:         testType{TestData: "testValue"},
+		expectedData: []byte(testJsonString),
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e, _ := NewArtifactPackagedEvent()
+			err := e.SetCustomData(tc.contentType, tc.data)
+			if err != nil {
+				t.Fatalf("expected to set the custom data, but got %v", err)
+			}
+
+			if d := cmp.Diff(tc.expectedData, e.CustomData); d != "" {
+				t.Errorf("args: diff(-want,+got):\n%s", d)
+			}
+		})
+	}
+}
+
+func TestSetCustomDataInvalid(t *testing.T) {
+	e, _ := NewArtifactPackagedEvent()
+	err := e.SetCustomData("application/xml", testType{TestData: "testValue"})
+	if err == nil {
+		t.Fatalf("did not expect this to work, but it did")
+	}
+}


### PR DESCRIPTION
Add custom data to the SDK as described in https://github.com/cdevents/spec/pull/63
Go objects can be passed directly, and the SDK will attempt
to marshal them as json.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>