### PR TITLE
Fix custom data implementation

### DIFF
--- a/jsonschema/artifactpackaged.json
+++ b/jsonschema/artifactpackaged.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/artifactpublished.json
+++ b/jsonschema/artifactpublished.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/branchcreated.json
+++ b/jsonschema/branchcreated.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/branchdeleted.json
+++ b/jsonschema/branchdeleted.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/buildfinished.json
+++ b/jsonschema/buildfinished.json
@@ -70,8 +70,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/buildqueued.json
+++ b/jsonschema/buildqueued.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/buildstarted.json
+++ b/jsonschema/buildstarted.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/changeabandoned.json
+++ b/jsonschema/changeabandoned.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/changecreated.json
+++ b/jsonschema/changecreated.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/changemerged.json
+++ b/jsonschema/changemerged.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/changereviewed.json
+++ b/jsonschema/changereviewed.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/changeupdated.json
+++ b/jsonschema/changeupdated.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/environmentcreated.json
+++ b/jsonschema/environmentcreated.json
@@ -73,8 +73,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/environmentdeleted.json
+++ b/jsonschema/environmentdeleted.json
@@ -70,8 +70,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/environmentmodified.json
+++ b/jsonschema/environmentmodified.json
@@ -73,8 +73,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/pipelinerunfinished.json
+++ b/jsonschema/pipelinerunfinished.json
@@ -79,8 +79,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/pipelinerunqueued.json
+++ b/jsonschema/pipelinerunqueued.json
@@ -79,8 +79,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/pipelinerunstarted.json
+++ b/jsonschema/pipelinerunstarted.json
@@ -77,8 +77,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/repositorycreated.json
+++ b/jsonschema/repositorycreated.json
@@ -85,8 +85,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/repositorydeleted.json
+++ b/jsonschema/repositorydeleted.json
@@ -79,8 +79,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/repositorymodified.json
+++ b/jsonschema/repositorymodified.json
@@ -79,8 +79,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/servicedeployed.json
+++ b/jsonschema/servicedeployed.json
@@ -83,8 +83,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/servicepublished.json
+++ b/jsonschema/servicepublished.json
@@ -83,8 +83,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/serviceremoved.json
+++ b/jsonschema/serviceremoved.json
@@ -83,8 +83,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/servicerolledback.json
+++ b/jsonschema/servicerolledback.json
@@ -83,8 +83,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/serviceupgraded.json
+++ b/jsonschema/serviceupgraded.json
@@ -83,8 +83,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/taskrunfinished.json
+++ b/jsonschema/taskrunfinished.json
@@ -95,8 +95,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/taskrunstarted.json
+++ b/jsonschema/taskrunstarted.json
@@ -89,8 +89,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/testcasefinished.json
+++ b/jsonschema/testcasefinished.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/testcasequeued.json
+++ b/jsonschema/testcasequeued.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/testcasestarted.json
+++ b/jsonschema/testcasestarted.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/testsuitefinished.json
+++ b/jsonschema/testsuitefinished.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/jsonschema/testsuitestarted.json
+++ b/jsonschema/testsuitestarted.json
@@ -66,8 +66,14 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/pkg/api/artifactpackaged.go
+++ b/pkg/api/artifactpackaged.go
@@ -83,12 +83,16 @@ func (e ArtifactPackagedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ArtifactPackagedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ArtifactPackagedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ArtifactPackagedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ArtifactPackagedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ArtifactPackagedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *ArtifactPackagedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ArtifactPackagedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/artifactpublished.go
+++ b/pkg/api/artifactpublished.go
@@ -83,12 +83,16 @@ func (e ArtifactPublishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ArtifactPublishedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ArtifactPublishedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ArtifactPublishedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ArtifactPublishedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ArtifactPublishedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *ArtifactPublishedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ArtifactPublishedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/bindings.go
+++ b/pkg/api/bindings.go
@@ -68,12 +68,16 @@ var (
 
 	// Map schema names to schema strings
 	allEventSchemas map[string]string
+
+	// Map CDEventType to empty event objects
+	cdeventTypesToReceiver map[CDEventType]CDEvent
 )
 
 func init() {
 
 	// Init the schema map
 	allEventSchemas = make(map[string]string)
+	cdeventTypesToReceiver = make(map[CDEventType]CDEvent)
 
 	// Setup a reflector
 	id := schemaproducer.EmptyID
@@ -83,12 +87,15 @@ func init() {
 		DoNotReference: true,
 	}
 
-	// Setup schema strings
 	for _, eventType := range allEvents {
+		// Setup schema strings
 		s := reflector.Reflect(eventType)
 		data, err := json.MarshalIndent(s, "", "  ")
 		panicOnError(err)
 		allEventSchemas[eventType.GetSchema()] = string(data)
+
+		// Set type to receiver map
+		cdeventTypesToReceiver[eventType.GetType()] = eventType
 	}
 }
 

--- a/pkg/api/branchcreated.go
+++ b/pkg/api/branchcreated.go
@@ -83,12 +83,16 @@ func (e BranchCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e BranchCreatedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e BranchCreatedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BranchCreatedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e BranchCreatedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BranchCreatedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *BranchCreatedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *BranchCreatedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/branchdeleted.go
+++ b/pkg/api/branchdeleted.go
@@ -83,12 +83,16 @@ func (e BranchDeletedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e BranchDeletedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e BranchDeletedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BranchDeletedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e BranchDeletedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BranchDeletedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *BranchDeletedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *BranchDeletedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/buildfinished.go
+++ b/pkg/api/buildfinished.go
@@ -87,12 +87,16 @@ func (e BuildFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e BuildFinishedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e BuildFinishedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BuildFinishedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e BuildFinishedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BuildFinishedEvent) GetCustomDataContentType() string {
@@ -126,11 +130,12 @@ func (e *BuildFinishedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *BuildFinishedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/buildqueued.go
+++ b/pkg/api/buildqueued.go
@@ -83,12 +83,16 @@ func (e BuildQueuedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e BuildQueuedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e BuildQueuedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BuildQueuedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e BuildQueuedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BuildQueuedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *BuildQueuedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *BuildQueuedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/buildstarted.go
+++ b/pkg/api/buildstarted.go
@@ -83,12 +83,16 @@ func (e BuildStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e BuildStartedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e BuildStartedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BuildStartedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e BuildStartedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e BuildStartedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *BuildStartedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *BuildStartedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/changeabandoned.go
+++ b/pkg/api/changeabandoned.go
@@ -83,12 +83,16 @@ func (e ChangeAbandonedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ChangeAbandonedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ChangeAbandonedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeAbandonedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeAbandonedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeAbandonedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *ChangeAbandonedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ChangeAbandonedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/changecreated.go
+++ b/pkg/api/changecreated.go
@@ -83,12 +83,16 @@ func (e ChangeCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ChangeCreatedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ChangeCreatedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeCreatedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeCreatedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeCreatedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *ChangeCreatedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ChangeCreatedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/changemerged.go
+++ b/pkg/api/changemerged.go
@@ -83,12 +83,16 @@ func (e ChangeMergedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ChangeMergedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ChangeMergedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeMergedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeMergedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeMergedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *ChangeMergedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ChangeMergedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/changereviewed.go
+++ b/pkg/api/changereviewed.go
@@ -83,12 +83,16 @@ func (e ChangeReviewedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ChangeReviewedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ChangeReviewedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeReviewedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeReviewedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeReviewedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *ChangeReviewedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ChangeReviewedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/changeupdated.go
+++ b/pkg/api/changeupdated.go
@@ -83,12 +83,16 @@ func (e ChangeUpdatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ChangeUpdatedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ChangeUpdatedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeUpdatedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ChangeUpdatedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ChangeUpdatedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *ChangeUpdatedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ChangeUpdatedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/environmentcreated.go
+++ b/pkg/api/environmentcreated.go
@@ -90,12 +90,16 @@ func (e EnvironmentCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e EnvironmentCreatedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e EnvironmentCreatedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e EnvironmentCreatedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e EnvironmentCreatedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e EnvironmentCreatedEvent) GetCustomDataContentType() string {
@@ -129,11 +133,12 @@ func (e *EnvironmentCreatedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *EnvironmentCreatedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/environmentdeleted.go
+++ b/pkg/api/environmentdeleted.go
@@ -87,12 +87,16 @@ func (e EnvironmentDeletedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e EnvironmentDeletedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e EnvironmentDeletedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e EnvironmentDeletedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e EnvironmentDeletedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e EnvironmentDeletedEvent) GetCustomDataContentType() string {
@@ -126,11 +130,12 @@ func (e *EnvironmentDeletedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *EnvironmentDeletedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/environmentmodified.go
+++ b/pkg/api/environmentmodified.go
@@ -90,12 +90,16 @@ func (e EnvironmentModifiedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e EnvironmentModifiedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e EnvironmentModifiedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e EnvironmentModifiedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e EnvironmentModifiedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e EnvironmentModifiedEvent) GetCustomDataContentType() string {
@@ -129,11 +133,12 @@ func (e *EnvironmentModifiedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *EnvironmentModifiedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/pipelinerunfinished.go
+++ b/pkg/api/pipelinerunfinished.go
@@ -112,12 +112,16 @@ func (e PipelineRunFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e PipelineRunFinishedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e PipelineRunFinishedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e PipelineRunFinishedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e PipelineRunFinishedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e PipelineRunFinishedEvent) GetCustomDataContentType() string {
@@ -152,11 +156,12 @@ func (e *PipelineRunFinishedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *PipelineRunFinishedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/pipelinerunqueued.go
+++ b/pkg/api/pipelinerunqueued.go
@@ -90,12 +90,16 @@ func (e PipelineRunQueuedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e PipelineRunQueuedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e PipelineRunQueuedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e PipelineRunQueuedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e PipelineRunQueuedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e PipelineRunQueuedEvent) GetCustomDataContentType() string {
@@ -130,11 +134,12 @@ func (e *PipelineRunQueuedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *PipelineRunQueuedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/pipelinerunstarted.go
+++ b/pkg/api/pipelinerunstarted.go
@@ -90,12 +90,16 @@ func (e PipelineRunStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e PipelineRunStartedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e PipelineRunStartedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e PipelineRunStartedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e PipelineRunStartedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e PipelineRunStartedEvent) GetCustomDataContentType() string {
@@ -130,11 +134,12 @@ func (e *PipelineRunStartedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *PipelineRunStartedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/repositorycreated.go
+++ b/pkg/api/repositorycreated.go
@@ -96,12 +96,16 @@ func (e RepositoryCreatedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e RepositoryCreatedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e RepositoryCreatedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e RepositoryCreatedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e RepositoryCreatedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e RepositoryCreatedEvent) GetCustomDataContentType() string {
@@ -135,11 +139,12 @@ func (e *RepositoryCreatedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *RepositoryCreatedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/repositorydeleted.go
+++ b/pkg/api/repositorydeleted.go
@@ -96,12 +96,16 @@ func (e RepositoryDeletedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e RepositoryDeletedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e RepositoryDeletedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e RepositoryDeletedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e RepositoryDeletedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e RepositoryDeletedEvent) GetCustomDataContentType() string {
@@ -135,11 +139,12 @@ func (e *RepositoryDeletedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *RepositoryDeletedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/repositorymodified.go
+++ b/pkg/api/repositorymodified.go
@@ -96,12 +96,16 @@ func (e RepositoryModifiedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e RepositoryModifiedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e RepositoryModifiedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e RepositoryModifiedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e RepositoryModifiedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e RepositoryModifiedEvent) GetCustomDataContentType() string {
@@ -135,11 +139,12 @@ func (e *RepositoryModifiedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *RepositoryModifiedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/servicedeployed.go
+++ b/pkg/api/servicedeployed.go
@@ -87,12 +87,16 @@ func (e ServiceDeployedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ServiceDeployedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ServiceDeployedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceDeployedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceDeployedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceDeployedEvent) GetCustomDataContentType() string {
@@ -126,11 +130,12 @@ func (e *ServiceDeployedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ServiceDeployedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/servicepublished.go
+++ b/pkg/api/servicepublished.go
@@ -87,12 +87,16 @@ func (e ServicePublishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ServicePublishedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ServicePublishedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServicePublishedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ServicePublishedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServicePublishedEvent) GetCustomDataContentType() string {
@@ -126,11 +130,12 @@ func (e *ServicePublishedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ServicePublishedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/serviceremoved.go
+++ b/pkg/api/serviceremoved.go
@@ -87,12 +87,16 @@ func (e ServiceRemovedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ServiceRemovedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ServiceRemovedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceRemovedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceRemovedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceRemovedEvent) GetCustomDataContentType() string {
@@ -126,11 +130,12 @@ func (e *ServiceRemovedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ServiceRemovedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/servicerolledback.go
+++ b/pkg/api/servicerolledback.go
@@ -87,12 +87,16 @@ func (e ServiceRolledbackEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ServiceRolledbackEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ServiceRolledbackEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceRolledbackEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceRolledbackEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceRolledbackEvent) GetCustomDataContentType() string {
@@ -126,11 +130,12 @@ func (e *ServiceRolledbackEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ServiceRolledbackEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/serviceupgraded.go
+++ b/pkg/api/serviceupgraded.go
@@ -87,12 +87,16 @@ func (e ServiceUpgradedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e ServiceUpgradedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e ServiceUpgradedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceUpgradedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e ServiceUpgradedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e ServiceUpgradedEvent) GetCustomDataContentType() string {
@@ -126,11 +130,12 @@ func (e *ServiceUpgradedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *ServiceUpgradedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/taskrunfinished.go
+++ b/pkg/api/taskrunfinished.go
@@ -114,12 +114,16 @@ func (e TaskRunFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e TaskRunFinishedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e TaskRunFinishedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TaskRunFinishedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e TaskRunFinishedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TaskRunFinishedEvent) GetCustomDataContentType() string {
@@ -154,11 +158,12 @@ func (e *TaskRunFinishedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *TaskRunFinishedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/taskrunstarted.go
+++ b/pkg/api/taskrunstarted.go
@@ -93,12 +93,16 @@ func (e TaskRunStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e TaskRunStartedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e TaskRunStartedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TaskRunStartedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e TaskRunStartedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TaskRunStartedEvent) GetCustomDataContentType() string {
@@ -133,11 +137,12 @@ func (e *TaskRunStartedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *TaskRunStartedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/testcasefinished.go
+++ b/pkg/api/testcasefinished.go
@@ -83,12 +83,16 @@ func (e TestCaseFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e TestCaseFinishedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e TestCaseFinishedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestCaseFinishedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e TestCaseFinishedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestCaseFinishedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *TestCaseFinishedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *TestCaseFinishedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/testcasequeued.go
+++ b/pkg/api/testcasequeued.go
@@ -83,12 +83,16 @@ func (e TestCaseQueuedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e TestCaseQueuedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e TestCaseQueuedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestCaseQueuedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e TestCaseQueuedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestCaseQueuedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *TestCaseQueuedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *TestCaseQueuedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/testcasestarted.go
+++ b/pkg/api/testcasestarted.go
@@ -83,12 +83,16 @@ func (e TestCaseStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e TestCaseStartedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e TestCaseStartedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestCaseStartedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e TestCaseStartedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestCaseStartedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *TestCaseStartedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *TestCaseStartedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/testsuitefinished.go
+++ b/pkg/api/testsuitefinished.go
@@ -83,12 +83,16 @@ func (e TestSuiteFinishedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e TestSuiteFinishedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e TestSuiteFinishedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestSuiteFinishedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e TestSuiteFinishedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestSuiteFinishedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *TestSuiteFinishedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *TestSuiteFinishedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 

--- a/pkg/api/testsuitestarted.go
+++ b/pkg/api/testsuitestarted.go
@@ -83,12 +83,16 @@ func (e TestSuiteStartedEvent) GetSubject() Subject {
 	return e.Subject
 }
 
-func (e TestSuiteStartedEvent) GetCustomData() []byte {
-	return e.CustomData
+func (e TestSuiteStartedEvent) GetCustomData() (interface{}, error) {
+	return getCustomData(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestSuiteStartedEvent) GetCustomDataAs(receiver interface{}) error {
 	return getCustomDataAs(e, receiver)
+}
+
+func (e TestSuiteStartedEvent) GetCustomDataRaw() ([]byte, error) {
+	return getCustomDataRaw(e.CustomDataContentType, e.CustomData)
 }
 
 func (e TestSuiteStartedEvent) GetCustomDataContentType() string {
@@ -122,11 +126,12 @@ func (e *TestSuiteStartedEvent) SetSubjectSource(subjectSource string) {
 }
 
 func (e *TestSuiteStartedEvent) SetCustomData(contentType string, data interface{}) error {
-	dataBytes, err := customDataBytes(contentType, data)
+	err := checkCustomData(contentType, data)
 	if err != nil {
 		return err
 	}
-	e.CustomData = dataBytes
+	e.CustomData = data
+	e.CustomDataContentType = contentType
 	return nil
 }
 


### PR DESCRIPTION
Use a custom unmarshaller and jsonschema tags to fix the implementation of custom data.

`CustomData` contains the data as follows:

When the content type is "application/json":
 - if the CDEvent is produced via the golang API, the `CustomData` usually holds an un-marshalled golang interface{} of some type
 - if the CDEvent is consumed and thus un-marshalled from a []byte the `CustomData` holds the data as a []byte, so that it may be un-marshalled into a specific golang type via the `GetCustomDataAs`

When the content type is anything else:
 - the content data is always stored as []byte, as the SDK does not have enough knowledge about the data to un-marshal it into a golang type

Extend the interface to include GetCustomDataRaw which always returns a []byte.

Extend the test coverage.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>