### PR TITLE
Alter customData again. Add NewFromJson helpers

### DIFF
--- a/pkg/api/pipelinerunqueued.go
+++ b/pkg/api/pipelinerunqueued.go
@@ -39,7 +39,7 @@ type PipelineRunQueuedSubjectContent struct {
 
 type PipelineRunQueuedSubject struct {
 	SubjectBase
-	Content PipelineRunFinishedSubjectContent `json:"content"`
+	Content PipelineRunQueuedSubjectContent `json:"content"`
 }
 
 func (sc PipelineRunQueuedSubject) GetEventType() CDEventType {


### PR DESCRIPTION
Alter customData again. Add NewFromJson helpers

    Add methods that build a CDEvent from a JSON string or []byte.
    In the process alter customData handling slightly again:

    CDEventCustomData hosts the CDEvent custom data fields

    `CustomDataContentType` describes the content type of the data.

    `CustomData` contains the data:

    - When the content type is "application/json":

      - if the CDEvent is produced via the golang API, the `CustomData`
        can hold an un-marshalled golang interface{} of a specific type
        or a marshalled byte slice

      - if the CDEvent is consumed and thus un-marshalled from a []byte
        the `CustomData` holds the data un-marshalled from []byte, into
        a generic interface{}. It may be un-marshalled into a specific
        golang type via the `GetCustomDataAs`

    - When the content type is anything else:

      - if the CDEvent is produced via the golang API, the `CustomData`
        hold an byte slice with the data passed via the API

      - if the CDEvent is consumed and thus un-marshalled from a []byte
        the `CustomData` holds the data base64 encoded

    The GetCustomData takes care of the missing base64 decoding.
    Ideally the unmarshalling should take care of that, but my attempts
    of custom unmarshallers brake things, so this is a reasonable
    workaround for now.

    Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>