### PR TITLE
chore: fix error in readme for sending as cloudevent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To send a CDEvent as CloudEvent:
 ```golang
 func main() {
     // (...) set the event first
-    ce := cdevents.AsCloudEvent(event)
+    ce, err := cdevents.AsCloudEvent(event)
 
     // Set send options
     ctx := cloudevents.ContextWithTarget(context.Background(), "http://localhost:8080/")


### PR DESCRIPTION
Fix error in Readme for variables for sending cloudevent

Closes issue: https://github.com/cdevents/sdk-go/issues/32

Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>