### PR TITLE
Add support for complex objects in content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode
 
 dist/
+build/
+**/cover.out

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
-	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,9 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 h1:siQdpVirKtzPhKl3lZWozZraCFObP8S1v6PRp0bLrtU=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=

--- a/pkg/api/bindings_test.go
+++ b/pkg/api/bindings_test.go
@@ -67,6 +67,7 @@ func init() {
 	eventJsonCustomData.SetSubjectReferenceField(Reference{Id: testChangeId})
 	eventJsonCustomData.SetSubjectPlainField(testValue)
 	eventJsonCustomData.SetSubjectArtifactId(testArtifactId)
+	eventJsonCustomData.SetSubjectObjectField(FooSubjectBarPredicateSubjectContentObjectField{Required: testChangeId, Optional: testSource})
 	err := eventJsonCustomData.SetCustomData("application/json", testDataJson)
 	panicOnError(err)
 
@@ -75,6 +76,7 @@ func init() {
 	eventJsonCustomDataUnmarshalled.SetSubjectReferenceField(Reference{Id: testChangeId})
 	eventJsonCustomDataUnmarshalled.SetSubjectPlainField(testValue)
 	eventJsonCustomDataUnmarshalled.SetSubjectArtifactId(testArtifactId)
+	eventJsonCustomDataUnmarshalled.SetSubjectObjectField(FooSubjectBarPredicateSubjectContentObjectField{Required: testChangeId, Optional: testSource})
 	err = eventJsonCustomDataUnmarshalled.SetCustomData("application/json", testDataJsonUnmarshalled)
 	panicOnError(err)
 
@@ -83,6 +85,7 @@ func init() {
 	eventNonJsonCustomData.SetSubjectReferenceField(Reference{Id: testChangeId})
 	eventNonJsonCustomData.SetSubjectPlainField(testValue)
 	eventNonJsonCustomData.SetSubjectArtifactId(testArtifactId)
+	eventNonJsonCustomData.SetSubjectObjectField(FooSubjectBarPredicateSubjectContentObjectField{Required: testChangeId, Optional: testSource})
 	err = eventNonJsonCustomData.SetCustomData("application/xml", testDataXml)
 	panicOnError(err)
 
@@ -459,6 +462,7 @@ func testEventWithVersion(eventVersion string, specVersion string) *FooSubjectBa
 	event.SetSubjectReferenceField(Reference{Id: testChangeId})
 	event.SetSubjectPlainField(testValue)
 	event.SetSubjectArtifactId(testArtifactId)
+	event.SetSubjectObjectField(FooSubjectBarPredicateSubjectContentObjectField{Required: testChangeId, Optional: testSource})
 	err := event.SetCustomData("application/json", testDataJsonUnmarshalled)
 	panicOnError(err)
 	etype, err := ParseType(event.Context.Type)

--- a/pkg/api/tests/examples/future_event_minor_version.json
+++ b/pkg/api/tests/examples/future_event_minor_version.json
@@ -16,7 +16,11 @@
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
       "referenceField": {
         "id": "myChange123"
-      }
+      },
+			"objectField": {
+				"required": "myChange123",
+				"optional": "/event/source/123"
+			}
     },
     "newSubjectField": "ignored"
   },

--- a/pkg/api/tests/examples/future_event_patch_version.json
+++ b/pkg/api/tests/examples/future_event_patch_version.json
@@ -15,7 +15,11 @@
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
       "referenceField": {
         "id": "myChange123"
-      }
+      },
+			"objectField": {
+				"required": "myChange123",
+				"optional": "/event/source/123"
+			}
     }
   },
   "customData": {

--- a/pkg/api/tests/examples/implicit_json_custom_data.json
+++ b/pkg/api/tests/examples/implicit_json_custom_data.json
@@ -15,6 +15,10 @@
 			"plainField": "testValue",
 			"referenceField": {
 				"id": "myChange123"
+			},
+			"objectField": {
+				"required": "myChange123",
+				"optional": "/event/source/123"
 			}
 		}
 	},

--- a/pkg/api/tests/examples/json_custom_data.json
+++ b/pkg/api/tests/examples/json_custom_data.json
@@ -15,7 +15,11 @@
 				"id": "myChange123"
 			},
 			"artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
-			"plainField": "testValue"
+			"plainField": "testValue",
+			"objectField": {
+				"required": "myChange123",
+				"optional": "/event/source/123"
+			}
 		}
 	},
 	"customData": {

--- a/pkg/api/tests/examples/non_json_custom_data.json
+++ b/pkg/api/tests/examples/non_json_custom_data.json
@@ -15,7 +15,11 @@
 				"id": "myChange123"
 			},
 			"artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
-			"plainField": "testValue"
+			"plainField": "testValue",
+			"objectField": {
+				"required": "myChange123",
+				"optional": "/event/source/123"
+			}
 		}
 	},
 	"customData": "PHhtbD50ZXN0RGF0YTwveG1sPg==",

--- a/pkg/api/tests/schemas/foosubjectbarpredicate.json
+++ b/pkg/api/tests/schemas/foosubjectbarpredicate.json
@@ -83,7 +83,25 @@
 				]
 			  },
 			  "artifactId": {
-				"type": "string"			  }
+				"type": "string"
+			  },
+			  "objectField": {
+				"properties": {
+				  "required": {
+					"type": "string",
+					"minLength": 1
+				  },
+				  "optional": {
+					"type": "string",
+					"format": "uri-reference"
+				  }
+				},
+				"additionalProperties": false,
+				"type": "object",
+				"required": [
+				  "required"
+				]
+			  }
 			},
 			"additionalProperties": false,
 			"type": "object",

--- a/pkg/api/zz_ztest_foosubjectbarpredicate.go
+++ b/pkg/api/zz_ztest_foosubjectbarpredicate.go
@@ -25,7 +25,7 @@ import (
 	"time"
 )
 
-var foosubjectbarpredicateschema = `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://cdevents.dev/0.2.0/schema/foosubject-barpredicate-event","properties":{"context":{"properties":{"version":{"type":"string","minLength":1},"id":{"type":"string","minLength":1},"source":{"type":"string","minLength":1,"format":"uri-reference"},"type":{"type":"string","enum":["dev.cdevents.foosubject.barpredicate.1.2.3"],"default":"dev.cdevents.foosubject.barpredicate.1.2.3"},"timestamp":{"type":"string","format":"date-time"}},"additionalProperties":false,"type":"object","required":["version","id","source","type","timestamp"]},"subject":{"properties":{"id":{"type":"string","minLength":1},"source":{"type":"string","minLength":1,"format":"uri-reference"},"type":{"type":"string","minLength":1,"enum":["fooSubject"],"default":"fooSubject"},"content":{"properties":{"plainField":{"type":"string","minLength":1},"referenceField":{"properties":{"id":{"type":"string","minLength":1},"source":{"type":"string","minLength":1,"format":"uri-reference"}},"additionalProperties":false,"type":"object","required":["id"]},"artifactId":{"type":"string"}},"additionalProperties":false,"type":"object","required":["plainField","referenceField"]}},"additionalProperties":false,"type":"object","required":["id","type","content"]},"customData":{"oneOf":[{"type":"object"},{"type":"string","contentEncoding":"base64"}]},"customDataContentType":{"type":"string"}},"additionalProperties":false,"type":"object","required":["context","subject"]}`
+var foosubjectbarpredicateschema = `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://cdevents.dev/0.2.0/schema/foosubject-barpredicate-event","properties":{"context":{"properties":{"version":{"type":"string","minLength":1},"id":{"type":"string","minLength":1},"source":{"type":"string","minLength":1,"format":"uri-reference"},"type":{"type":"string","enum":["dev.cdevents.foosubject.barpredicate.1.2.3"],"default":"dev.cdevents.foosubject.barpredicate.1.2.3"},"timestamp":{"type":"string","format":"date-time"}},"additionalProperties":false,"type":"object","required":["version","id","source","type","timestamp"]},"subject":{"properties":{"id":{"type":"string","minLength":1},"source":{"type":"string","minLength":1,"format":"uri-reference"},"type":{"type":"string","minLength":1,"enum":["fooSubject"],"default":"fooSubject"},"content":{"properties":{"plainField":{"type":"string","minLength":1},"referenceField":{"properties":{"id":{"type":"string","minLength":1},"source":{"type":"string","minLength":1,"format":"uri-reference"}},"additionalProperties":false,"type":"object","required":["id"]},"artifactId":{"type":"string"},"objectField":{"properties":{"required":{"type":"string","minLength":1},"optional":{"type":"string","format":"uri-reference"}},"additionalProperties":false,"type":"object","required":["required"]}},"additionalProperties":false,"type":"object","required":["plainField","referenceField"]}},"additionalProperties":false,"type":"object","required":["id","type","content"]},"customData":{"oneOf":[{"type":"object"},{"type":"string","contentEncoding":"base64"}]},"customDataContentType":{"type":"string"}},"additionalProperties":false,"type":"object","required":["context","subject"]}`
 
 var (
 	// FooSubjectBarPredicate event v1.2.3
@@ -38,6 +38,8 @@ var (
 
 type FooSubjectBarPredicateSubjectContent struct {
 	ArtifactId string `json:"artifactId" validate:"purl"`
+
+	ObjectField FooSubjectBarPredicateSubjectContentObjectField `json:"objectField"`
 
 	PlainField string `json:"plainField"`
 
@@ -160,6 +162,10 @@ func (e *FooSubjectBarPredicateEvent) SetSubjectArtifactId(artifactId string) {
 	e.Subject.Content.ArtifactId = artifactId
 }
 
+func (e *FooSubjectBarPredicateEvent) SetSubjectObjectField(objectField FooSubjectBarPredicateSubjectContentObjectField) {
+	e.Subject.Content.ObjectField = objectField
+}
+
 func (e *FooSubjectBarPredicateEvent) SetSubjectPlainField(plainField string) {
 	e.Subject.Content.PlainField = plainField
 }
@@ -186,4 +192,11 @@ func NewFooSubjectBarPredicateEvent() (*FooSubjectBarPredicateEvent, error) {
 	e.SetTimestamp(t)
 	e.SetId("271069a8-fc18-44f1-b38f-9d70a1695819")
 	return e, nil
+}
+
+// FooSubjectBarPredicateSubjectContentObjectField holds the content of a ObjectField field in the content
+type FooSubjectBarPredicateSubjectContentObjectField struct {
+	Optional string `json:"optional"`
+
+	Required string `json:"required"`
 }

--- a/tools/generator_test.go
+++ b/tools/generator_test.go
@@ -70,8 +70,23 @@ func TestDataFromSchema(t *testing.T) {
 			Name:      "PlainField",
 			NameLower: "plainField",
 			Type:      "string",
-		},
-		},
+		}, {
+			Name:      "ObjectField",
+			NameLower: "objectField",
+			Type:      "ObjectField",
+		}},
+		ContentTypes: []ContentType{{
+			Name: "ObjectField",
+			Fields: []ContentField{{
+				Name:      "Required",
+				NameLower: "required",
+				Type:      "string",
+			}, {
+				Name:      "Optional",
+				NameLower: "optional",
+				Type:      "string",
+			}},
+		}},
 	}
 
 	mappings := map[string]string{

--- a/tools/templates/event.go.tmpl
+++ b/tools/templates/event.go.tmpl
@@ -38,11 +38,7 @@ var (
 
 type {{.Subject}}{{.Predicate}}SubjectContent  struct{
 {{ range $i, $field := .Contents }}
-{{ if eq .Name "ArtifactId" }}
-	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}" validate:"purl"`
-{{- else }}
-	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}"`
-{{- end }}
+	{{ .Name }} {{ if and (ne .Type "string") (ne .Type "Reference") }}{{$.Subject}}{{$.Predicate}}SubjectContent{{ end }}{{ .Type }} `json:"{{ .NameLower }}"{{ if eq .Name "ArtifactId" }} validate:"purl"{{ end }}`
 {{ end }}
 }
 
@@ -154,7 +150,7 @@ func (e {{.Subject}}{{.Predicate}}Event) GetSchema() (string, string) {
 
 // Set subject custom fields
 {{ range $i, $field := .Contents }}
-func (e *{{$.Subject}}{{$.Predicate}}Event) SetSubject{{ .Name }}({{ .NameLower }} {{ .Type }}) {
+func (e *{{$.Subject}}{{$.Predicate}}Event) SetSubject{{ .Name }}({{ .NameLower }} {{ if and (ne .Type "string") (ne .Type "Reference") }}{{$.Subject}}{{$.Predicate}}SubjectContent{{ end }}{{ .Type }}) {
 	e.Subject.Content.{{ .Name }} = {{ .NameLower }}
 }
 {{ end }}
@@ -178,3 +174,12 @@ func New{{.Subject}}{{.Predicate}}Event() (*{{.Subject}}{{.Predicate}}Event, err
 	}
 	return e, nil
 }
+
+{{ range $i, $type := .ContentTypes }}
+// {{$.Subject}}{{$.Predicate}}SubjectContent{{ .Name }} holds the content of a {{ .Name }} field in the content 
+type {{$.Subject}}{{$.Predicate}}SubjectContent{{ .Name }} struct{
+{{ range $j, $field := .Fields }}
+	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}"`
+{{ end }}
+}
+{{ end }}

--- a/tools/templates_test/event.go.tmpl
+++ b/tools/templates_test/event.go.tmpl
@@ -38,11 +38,7 @@ var (
 
 type {{.Subject}}{{.Predicate}}SubjectContent  struct{
 {{ range $i, $field := .Contents }}
-{{ if eq .Name "ArtifactId" }}
-	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}" validate:"purl"`
-{{- else }}
-	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}"`
-{{- end }}
+	{{ .Name }} {{ if and (ne .Type "string") (ne .Type "Reference") }}{{$.Subject}}{{$.Predicate}}SubjectContent{{ end }}{{ .Type }} `json:"{{ .NameLower }}"{{ if eq .Name "ArtifactId" }} validate:"purl"{{ end }}`
 {{ end }}
 }
 
@@ -158,7 +154,7 @@ func (e {{.Subject}}{{.Predicate}}Event) GetSchema() (string, string) {
 
 // Set subject custom fields
 {{ range $i, $field := .Contents }}
-func (e *{{$.Subject}}{{$.Predicate}}Event) SetSubject{{ .Name }}({{ .NameLower }} {{ .Type }}) {
+func (e *{{$.Subject}}{{$.Predicate}}Event) SetSubject{{ .Name }}({{ .NameLower }} {{ if and (ne .Type "string") (ne .Type "Reference") }}{{$.Subject}}{{$.Predicate}}SubjectContent{{ end }}{{ .Type }}) {
 	e.Subject.Content.{{ .Name }} = {{ .NameLower }}
 }
 {{ end }}
@@ -182,3 +178,12 @@ func New{{.Subject}}{{.Predicate}}Event() (*{{.Subject}}{{.Predicate}}Event, err
 	e.SetId("271069a8-fc18-44f1-b38f-9d70a1695819")
 	return e, nil
 }
+
+{{ range $i, $type := .ContentTypes }}
+// {{$.Subject}}{{$.Predicate}}SubjectContent{{ .Name }} holds the content of a {{ .Name }} field in the content 
+type {{$.Subject}}{{$.Predicate}}SubjectContent{{ .Name }} struct{
+{{ range $j, $field := .Fields }}
+	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}"`
+{{ end }}
+}
+{{ end }}


### PR DESCRIPTION
The generator script allows for content field to be either string or "References". This extends the generator to allow for content fields being objects, with the limitations that object must themselves be made of string fields alone.

Templates are extended to define new structs that hold the object types and to use those types where needed.