### PR TITLE
Fix spec version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.10.1
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.1.2
-	github.com/package-url/packageurl-go v0.1.0
+	github.com/package-url/packageurl-go v0.1.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	golang.org/x/text v0.3.7
 )

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
-github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
+github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
+github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/api/tests/examples/future_event_major_version.json
+++ b/pkg/api/tests/examples/future_event_major_version.json
@@ -1,6 +1,6 @@
 {
   "context": {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.foosubject.barpredicate.999.0.0",

--- a/pkg/api/tests/examples/future_event_minor_version.json
+++ b/pkg/api/tests/examples/future_event_minor_version.json
@@ -1,6 +1,6 @@
 {
   "context": {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.foosubject.barpredicate.1.999.0",

--- a/pkg/api/tests/examples/future_event_patch_version.json
+++ b/pkg/api/tests/examples/future_event_patch_version.json
@@ -1,6 +1,6 @@
 {
   "context": {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.foosubject.barpredicate.1.2.999",

--- a/pkg/api/tests/examples/implicit_json_custom_data.json
+++ b/pkg/api/tests/examples/implicit_json_custom_data.json
@@ -1,6 +1,6 @@
 {
 	"context": {
-		"version": "0.2.0",
+		"version": "0.3.0",
 		"id": "271069a8-fc18-44f1-b38f-9d70a1695819",
 		"source": "/event/source/123",
 		"type": "dev.cdevents.foosubject.barpredicate.1.2.3",

--- a/pkg/api/tests/examples/json_custom_data.json
+++ b/pkg/api/tests/examples/json_custom_data.json
@@ -1,6 +1,6 @@
 {
 	"context": {
-		"version": "0.2.0",
+		"version": "0.3.0",
 		"id": "271069a8-fc18-44f1-b38f-9d70a1695819",
 		"source": "/event/source/123",
 		"type": "dev.cdevents.foosubject.barpredicate.1.2.3",

--- a/pkg/api/tests/examples/non_json_custom_data.json
+++ b/pkg/api/tests/examples/non_json_custom_data.json
@@ -1,6 +1,6 @@
 {
 	"context": {
-		"version": "0.2.0",
+		"version": "0.3.0",
 		"id": "271069a8-fc18-44f1-b38f-9d70a1695819",
 		"source": "/event/source/123",
 		"type": "dev.cdevents.foosubject.barpredicate.1.2.3",

--- a/pkg/api/tests/examples/past_event_patch_version.json
+++ b/pkg/api/tests/examples/past_event_patch_version.json
@@ -1,6 +1,6 @@
 {
   "context": {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.foosubject.barpredicate.1.2.0",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	EventTypeRoot             = "dev.cdevents"
-	CDEventsSpecVersion       = "0.2.0"
+	CDEventsSpecVersion       = "0.3.0"
 	CDEventsSchemaURLTemplate = "https://cdevents.dev/%s/schema/%s-%s-event"
 	CDEventsTypeRegex         = "^dev\\.cdevents\\.(?P<subject>[a-z]+)\\.(?P<predicate>[a-z]+)\\.(?P<version>.*)$"
 )


### PR DESCRIPTION
The SDK release 0.3.0 should produce events with spec version 0.3.0, but it was still using 0.2.0, so fixing that.

PackageURL produced a new v0.1.1 release that includes the OCI type in the go SDK, so pulling that in as oci is the type we use in the spec