### PR TITLE
Set the CloudEvent ID to match CDEvents Id

### DIFF
--- a/pkg/api/bindings.go
+++ b/pkg/api/bindings.go
@@ -98,6 +98,7 @@ func AsCloudEvent(event CDEventReader) (*cloudevents.Event, error) {
 		return nil, fmt.Errorf("cannot validate CDEvent %v", err)
 	}
 	ce := cloudevents.NewEvent()
+	ce.SetID(event.GetId())
 	ce.SetSource(event.GetSource())
 	ce.SetSubject(event.GetSubjectId())
 	ce.SetType(event.GetType().String())

--- a/pkg/api/bindings_test.go
+++ b/pkg/api/bindings_test.go
@@ -116,6 +116,9 @@ func TestAsCloudEvent(t *testing.T) {
 			if err != nil {
 				t.Fatalf("didn't expected it to fail, but it did: %v", err)
 			}
+			if d := cmp.Diff(tc.event.GetId(), ce.Context.GetID()); d != "" {
+				t.Errorf("args: diff(-want,+got):\n%s", d)
+			}
 			if d := cmp.Diff(testSubjectId, ce.Context.GetSubject()); d != "" {
 				t.Errorf("args: diff(-want,+got):\n%s", d)
 			}


### PR DESCRIPTION
When using the CloudEvent binding, the CloudEvent ID must match, according to the specification, with the CDEvents Id.

This can be done today by the event producer via the CloudEvents and CDEvents SDKs, however, since it's required by the spec, it's better implemented as default by the CDEvents SDK directly.

Fixes: #57