### PR TITLE
Adding `cdevents` tag name for copying struct fields

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -75,7 +75,7 @@ type Context struct {
 	// purpose of the source is to provide global uniqueness for source + id.
 	// The source MAY identify a single producer or a group of producer that
 	// belong to the same application.
-	Source string `json:"source" jsonschema:"required,minLength=1" validate:"uri-reference"`
+	Source string `json:"source" jsonschema:"required,minLength=1" validate:"uri-reference" cdevents:"context_source"`
 
 	// Spec: https://cdevents.dev/docs/spec/#type
 	// Description: defines the type of event, as combination of a subject and
@@ -98,14 +98,14 @@ type Reference struct {
 
 	// Spec: https://cdevents.dev/docs/spec/#format-of-subjects
 	// Description: Uniquely identifies the subject within the source
-	Id string `json:"id" jsonschema:"required,minLength=1"`
+	Id string `json:"id" jsonschema:"required,minLength=1" cdevents:"subject_id"`
 
 	// Spec: https://cdevents.dev/docs/spec/#format-of-subjects
 	// Description: defines the context in which an event happened. The main
 	// purpose of the source is to provide global uniqueness for source + id.
 	// The source MAY identify a single producer or a group of producer that
 	// belong to the same application.
-	Source string `json:"source,omitempty" validate:"uri-reference"`
+	Source string `json:"source,omitempty" validate:"uri-reference" cdevents:"subject_source"`
 }
 
 type SubjectBase struct {

--- a/tools/templates/event.go.tmpl
+++ b/tools/templates/event.go.tmpl
@@ -41,7 +41,7 @@ var (
 
 type {{.Subject}}{{.Predicate}}SubjectContent  struct{
 {{ range $i, $field := .Contents }}
-	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}{{ if not .Required }},omitempty{{ end }}"{{ if eq .Name "ArtifactId" }} validate:"purl"{{ end }}`
+	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}{{ if not .Required }},omitempty{{ end }}"{{ if eq .Name "ArtifactId" }} validate:"purl"{{ end }} cdevents:"{{ .NameLower }}"`
 {{ end }}
 }
 
@@ -189,7 +189,7 @@ func New{{.Subject}}{{.Predicate}}EventV{{.VersionName}}(specVersion string) (*{
 // {{$.Subject}}{{$.Predicate}}SubjectContent{{ .Name }} holds the content of a {{ .Name }} field in the content 
 type {{$.Subject}}{{$.Predicate}}SubjectContent{{ .Name }} struct{
 {{ range $j, $field := .Fields }}
-	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}{{ if not .Required }},omitempty{{ end }}"`
+	{{ .Name }} {{ .Type }} `json:"{{ .NameLower }}{{ if not .Required }},omitempty{{ end }}" cdevents:"{{ .NameLower }}"`
 {{ end }}
 }
 {{ end }}


### PR DESCRIPTION
This PR includes the changes to add `cdevents` tag name for CDEvents Subject and Context fields, this will help in copying the struct fields directly from any other source event to CDEvents type event, even the field names are different by using libraries like [mapstructure](https://github.com/mitchellh/mapstructure), [deepcopier](https://github.com/ulule/deepcopier), [copier](https://github.com/jinzhu/copier) or [copygen](https://github.com/switchupcb/copygen).

`````
type ProjectCreatedEvent struct {
	ProjectName string `cdevents:"name"`
	RepoURL string `cdevents:"url"`
}

type RepositoryCreatedCDEvent struct {
	Name string `cdevents:"name"`
	Url string `cdevents:"url"`
}
`````
Note:
1. With this change If anyone using  `cdevents` tag names and in future any of the field name changed, it will be a breaking change for the current users.(They need to update the tag name as per the change)