### PR TITLE
fix: avoid singleton mutation in NewFromJsonBytesContext

### DIFF
--- a/pkg/api/bindings.go
+++ b/pkg/api/bindings.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"reflect"
 	"regexp"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -218,6 +219,10 @@ func NewFromJsonBytesContext[CDEventType CDEvent](event []byte, cdeventsMap map[
 			return nilReturn, fmt.Errorf("sdk event version %s not compatible with %s", receiver.GetType().Version, eventType.Version)
 		}
 	}
+	// Create a fresh instance of the concrete type to avoid mutating the
+	// singleton stored in cdeventsMap. Without this, omitempty fields from a
+	// previous call would bleed into subsequent calls for the same event type.
+	receiver = reflect.New(reflect.TypeOf(receiver).Elem()).Interface().(CDEventType)
 	err = json.Unmarshal(event, receiver)
 	if err != nil {
 		return nilReturn, err

--- a/pkg/api/bindings_test.go
+++ b/pkg/api/bindings_test.go
@@ -582,6 +582,44 @@ func TestNewFromJsonString(t *testing.T) {
 	}
 }
 
+func TestNewFromJsonBytesNoSingletonMutation(t *testing.T) {
+	tests := []struct {
+		name         string
+		firstFile    string
+		secondFile   string
+		wantArtifact string
+	}{{
+		name:         "omitempty field from first event does not bleed into second",
+		firstFile:    "singleton_bleed_with_field",
+		secondFile:   "singleton_bleed_without_field",
+		wantArtifact: "",
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			firstBytes, err := os.ReadFile(testsFolder + string(os.PathSeparator) + tc.firstFile + ".json")
+			if err != nil {
+				t.Fatalf("failed to read first event fixture %s: %v", tc.firstFile, err)
+			}
+			secondBytes, err := os.ReadFile(testsFolder + string(os.PathSeparator) + tc.secondFile + ".json")
+			if err != nil {
+				t.Fatalf("failed to read second event fixture %s: %v", tc.secondFile, err)
+			}
+			_, err = testapi.NewFromJsonBytes(firstBytes)
+			if err != nil {
+				t.Fatalf("failed to parse first event %s: %v", tc.firstFile, err)
+			}
+			second, err := testapi.NewFromJsonBytes(secondBytes)
+			if err != nil {
+				t.Fatalf("failed to parse second event %s: %v", tc.secondFile, err)
+			}
+			content := second.GetSubjectContent().(api.FooSubjectBarPredicateSubjectContentV2_2_3)
+			if d := cmp.Diff(tc.wantArtifact, content.ArtifactId); d != "" {
+				t.Errorf("args: diff(-want,+got):\n%s", d)
+			}
+		})
+	}
+}
+
 func TestParseType(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/api/tests-v99.1/examples/implicit_json_custom_data.json
+++ b/pkg/api/tests-v99.1/examples/implicit_json_custom_data.json
@@ -4,7 +4,40 @@
 		"id": "271069a8-fc18-44f1-b38f-9d70a1695819",
 		"source": "/event/source/123",
 		"type": "dev.cdevents.foosubject.barpredicate.2.2.3",
-		"timestamp": "2023-03-20T14:27:05.315384Z"
+		"timestamp": "2023-03-20T14:27:05.315384Z",
+		"chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+		"schemaUri": "https://myorg.com/schema/custom",
+		"links": [
+		  {
+			"linkType": "RELATION",
+			"linkKind": "TRIGGER",
+			"target": {
+			  "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+			},
+			"tags": {
+			  "foo1": "bar",
+			  "foo2": "bar"
+			}
+		  }, {
+			"linkType": "PATH",
+			"from": {
+			  "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+			},
+			"tags": {
+			  "foo1": "bar",
+			  "foo2": "bar"
+			}
+		  }, {
+			"linkType": "END",
+			"from": {
+			  "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+			},
+			"tags": {
+			  "foo1": "bar",
+			  "foo2": "bar"
+			}
+		  }
+		]
 	},
 	"subject": {
 		"id": "mySubject123",
@@ -27,5 +60,6 @@
 			{"k1": "v1"},
 			{"k2": "v2"}
 		]
-	}
+	},
+	"customDataContentType": "application/json"
 }

--- a/pkg/api/tests-v99.1/examples/past_event_patch_version.json
+++ b/pkg/api/tests-v99.1/examples/past_event_patch_version.json
@@ -48,6 +48,10 @@
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
       "referenceField": {
         "id": "myChange123"
+      },
+      "objectField": {
+        "required": "myChange123",
+        "optional": "/event/source/123"
       }
     }
   },

--- a/pkg/api/tests-v99.1/examples/past_spec_patch_version.json
+++ b/pkg/api/tests-v99.1/examples/past_spec_patch_version.json
@@ -48,6 +48,10 @@
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
       "referenceField": {
         "id": "myChange123"
+      },
+      "objectField": {
+        "required": "myChange123",
+        "optional": "/event/source/123"
       }
     }
   },

--- a/pkg/api/tests-v99.1/examples/singleton_bleed_with_field.json
+++ b/pkg/api/tests-v99.1/examples/singleton_bleed_with_field.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "version": "99.1.0",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.foosubject.barpredicate.2.2.3",
+    "timestamp": "2023-03-20T14:27:05.315384Z"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "type": "fooSubject",
+    "content": {
+      "plainField": "testValue",
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "referenceField": {
+        "id": "myChange123"
+      }
+    }
+  }
+}

--- a/pkg/api/tests-v99.1/examples/singleton_bleed_without_field.json
+++ b/pkg/api/tests-v99.1/examples/singleton_bleed_without_field.json
@@ -1,0 +1,20 @@
+{
+  "context": {
+    "version": "99.1.0",
+    "id": "382170b9-ae29-55g2-c49g-0e81g96b5930",
+    "source": "/event/source/456",
+    "type": "dev.cdevents.foosubject.barpredicate.2.2.3",
+    "timestamp": "2023-03-20T15:00:00.000000Z"
+  },
+  "subject": {
+    "id": "mySubject456",
+    "source": "/event/source/456",
+    "type": "fooSubject",
+    "content": {
+      "plainField": "otherValue",
+      "referenceField": {
+        "id": "myChange456"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #125

`NewFromJsonBytesContext` unmarshals JSON directly into the singleton pointers stored in `CDEventsByUnversionedTypes`. Since `json.Unmarshal` doesn't zero `omitempty` fields absent from the input, values from a previous call leak into subsequent calls for the same event type. This also causes a data race when called concurrently.

The fix uses `reflect.New` to create a fresh instance of the concrete type before unmarshalling, so the map entries are only used for type lookup and never mutated.