### PR TITLE
fix: pin goimports to v0.42.0 to support Go 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ importfmt: get-fmt-deps
 	goimports -w $(GO_DEPENDENCIES)
 
 get-fmt-deps: ## Install test dependencies
-	$(GO) install golang.org/x/tools/cmd/goimports@latest
+	$(GO) install golang.org/x/tools/cmd/goimports@v0.42.0
 
 .PHONY: lint
 lint: ## Lint the code


### PR DESCRIPTION
## Summary

- `golang.org/x/tools@latest` resolved to v0.43.0 which requires Go >= 1.25
- The module declares `go 1.24.0` in `go.mod`, so CI fails with `GOTOOLCHAIN=local`
- Pins `goimports` to `v0.42.0`, the last release compatible with Go 1.24

## Test plan

- [ ] CI `make fmt` step passes without the `go >= 1.25.0` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)