### PR TITLE
fix: add ok check for CustomEventMapKey in NewFromJsonBytesContext

### DIFF
--- a/pkg/api/bindings.go
+++ b/pkg/api/bindings.go
@@ -199,7 +199,10 @@ func NewFromJsonBytesContext[CDEventType CDEvent](event []byte, cdeventsMap map[
 	}
 	eventType := eventAux.Context.GetType()
 	if eventType.Custom != "" {
-		receiver = cdeventsMap[CustomEventMapKey] // Custom type receiver does not have a predefined type
+		receiver, ok = cdeventsMap[CustomEventMapKey]
+		if !ok {
+			return nilReturn, fmt.Errorf("custom events not supported by this map")
+		}
 	} else {
 		receiver, ok = cdeventsMap[eventType.UnversionedString()]
 		if !ok {

--- a/pkg/api/bindings_test.go
+++ b/pkg/api/bindings_test.go
@@ -667,6 +667,23 @@ func testEventWithVersion(eventVersion string, specVersion string) *testapi.FooS
 	return event
 }
 
+func TestNewFromJsonBytesCustomEventUnsupported(t *testing.T) {
+	eventBytes, err := os.ReadFile(testsFolder + string(os.PathSeparator) + "custom_type_event.json")
+	if err != nil {
+		t.Fatalf("failed to read custom event fixture: %v", err)
+	}
+	// Use a map without CustomEventMapKey to trigger the error path
+	emptyMap := map[string]api.CDEventV04{}
+	_, err = api.NewFromJsonBytesContext[api.CDEventV04](eventBytes, emptyMap)
+	if err == nil {
+		t.Fatal("expected an error for missing CustomEventMapKey, got none")
+	}
+	wantError := "custom events not supported by this map"
+	if d := cmp.Diff(wantError, err.Error()); d != "" {
+		t.Errorf("error diff (-want,+got):\n%s", d)
+	}
+}
+
 func TestNewFromJsonBytes(t *testing.T) {
 	minorVersion := testEventWithVersion("2.999.1", testapi.SpecVersion)
 	patchVersion := testEventWithVersion("2.2.999", testapi.SpecVersion)

--- a/pkg/api/tests-v99.1/examples/custom_type_event.json
+++ b/pkg/api/tests-v99.1/examples/custom_type_event.json
@@ -1,0 +1,15 @@
+{
+  "context": {
+    "version": "99.1.0",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "source": "/event/source/123",
+    "type": "dev.cdeventsx.mytool-resource.created.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "type": "resource",
+    "content": {}
+  }
+}


### PR DESCRIPTION
## Summary

- The custom event path in `NewFromJsonBytesContext` did a map lookup on `CustomEventMapKey` without checking the `ok` flag
- If the key was absent, `receiver` would be the nil zero value for `CDEventType`
- A subsequent `reflect.TypeOf(receiver).Elem()` (or `json.Unmarshal`) would then panic
- Added the same guard used for the non-custom path: return a descriptive error instead

## Test plan

- [ ] Existing tests pass (`go test -tags testonly ./pkg/api/`)
- [ ] No panic when a `cdeventsMap` without `CustomEventMapKey` receives a custom event

🤖 Generated with [Claude Code](https://claude.com/claude-code)